### PR TITLE
ci(docker): split dev and latest release channels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,9 @@
 name: Docker
 
-# Two paths in: merges to main publish latest + sha tags once CI succeeds, and
-# release tags publish semver tags directly. A tag is cut from a commit that
+# Two release channels. Merges to main publish `dev` + a short commit SHA once
+# CI succeeds; stable `vX.Y.Z` tags publish semver tags and move `latest`.
+# Pre-release tags (`v0.2.0-rc1`) publish only their exact version, so `latest`
+# always means the newest stable release. A tag is cut from a commit that
 # already passed CI on main, so tag builds do not wait on a second CI run.
 #
 # Images are multi-arch. Each architecture builds on its own native runner and
@@ -123,13 +125,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # `type=sha` would read github.sha, which on workflow_run is the default
+      # branch head at event time, not necessarily the commit CI tested and the
+      # build job checked out. Derive the tag from the same ref as the checkout.
+      - name: Resolve built commit
+        id: src
+        env:
+          BUILT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: echo "short=${BUILT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          # latest=auto attaches `latest` only to a tag that parses as stable
+          # semver, so a malformed or pre-release tag can never move it. A
+          # hand-rolled ref check cannot express "valid semver".
+          flavor: |
+            latest=auto
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_run' }}
-            type=sha,prefix=,format=short
+            type=raw,value=dev,enable=${{ github.event_name == 'workflow_run' }}
+            type=raw,value=${{ steps.src.outputs.short }},priority=100
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 

--- a/backend/apps/ind-renderer/Dockerfile
+++ b/backend/apps/ind-renderer/Dockerfile
@@ -21,7 +21,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p ind-renderer && \
     cp /app/target/release/ind-renderer /usr/local/bin/ind-renderer
 
-FROM chromedp/headless-shell:latest
+# Pinned so a release rebuild gets the same Chrome as the main-channel build
+# of the same commit. Bump deliberately alongside renderer testing.
+FROM chromedp/headless-shell:151.0.7922.109
 
 RUN apt-get update && apt-get install -y \
     fonts-liberation \

--- a/website/src/content/docs/docs/self-hosting/operations.md
+++ b/website/src/content/docs/docs/self-hosting/operations.md
@@ -94,14 +94,18 @@ Take a database dump before upgrading. Migrations are forward-only; rolling
 back to an older image after a migration has run is not supported, so the dump
 is your way back.
 
-### Pinning versions
+### Release channels
 
-Every release publishes semver tags alongside `latest`:
+Every stable release publishes semver tags and moves `latest`. Merges to
+`main` publish `dev` and a short commit SHA and never move `latest`, so
+`latest` always means the newest stable release. Pre-releases such as
+`0.2.0-rc1` publish only their exact tag.
 
 ```yaml
 image: ghcr.io/useindelible/ind-api:0.1.0   # exact release
 image: ghcr.io/useindelible/ind-api:0.1     # latest patch of 0.1
-image: ghcr.io/useindelible/ind-api:latest  # tip of main
+image: ghcr.io/useindelible/ind-api:latest  # newest stable release
+image: ghcr.io/useindelible/ind-api:dev     # tip of main; unreleased, may break
 ```
 
 For production, pin `ind-api`, `ind-worker`, and `ind-renderer` to the same


### PR DESCRIPTION
Merges to `main` now publish `dev` + short SHA; `latest` moves only on stable `v*` tags; pre-releases publish only their exact version. The SHA tag derives from `workflow_run.head_sha` (the commit CI tested and the build checked out), not `github.sha`.

| Event | Tags |
|---|---|
| merge to main | `dev`, `<sha>` |
| `v0.2.0` | `0.2.0`, `0.2`, `latest`, `<sha>` |
| `v0.2.0-rc1` | `0.2.0-rc1`, `<sha>` |

Also pins the renderer's `chromedp/headless-shell` base to `151.0.7922.109` (current stable, same version today's `latest` builds use) so tag-time rebuilds match main-channel builds. `operations.md` documents the channels; quickstart compose keeps `:latest`, which now means newest stable.


