### PR TITLE
fix: website search indexing and web favicon

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/brand/indelible-mark-favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />

--- a/web/static/brand/indelible-mark-favicon.svg
+++ b/web/static/brand/indelible-mark-favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" color="#0071e3">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="12 12 176 176" color="#0071e3">
   <rect x="20" y="20" width="160" height="160" rx="42" fill="currentColor"/>
   <g fill="#ffffff">
     <rect x="88" y="38" width="24" height="52" rx="10"/>

--- a/web/tests/favicon.test.ts
+++ b/web/tests/favicon.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('application favicon', () => {
+	it('uses the shipped Indelible brand mark', () => {
+		const appHtml = readFileSync(resolve('src/app.html'), 'utf8');
+		const faviconPath = 'brand/indelible-mark-favicon.svg';
+
+		expect(appHtml).toContain(`href="%sveltekit.assets%/${faviconPath}"`);
+		expect(existsSync(resolve('static', faviconPath))).toBe(true);
+	});
+
+	it('fills the favicon canvas', () => {
+		const svg = readFileSync(resolve('static/brand/indelible-mark-favicon.svg'), 'utf8');
+		const viewBox = svg
+			.match(/viewBox="([\d.\s]+)"/)?.[1]
+			.split(/\s+/)
+			.map(Number);
+		const tileWidth = Number(svg.match(/<rect[^>]*width="([\d.]+)"/)?.[1]);
+
+		expect(viewBox).toHaveLength(4);
+		expect(tileWidth / viewBox![2]).toBeGreaterThanOrEqual(0.9);
+	});
+});

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import starlight from '@astrojs/starlight';
 import svelte from '@astrojs/svelte';
 
@@ -8,6 +9,9 @@ export default defineConfig({
 		'/docs': '/docs/getting-started/introduction/',
 	},
 	integrations: [
+		sitemap({
+			filter: (page) => page !== 'https://useindelible.com/screens/',
+		}),
 		starlight({
 			title: 'Indelible',
 			description: 'Open-source, self-hosted read-it-later and knowledge archiver.',

--- a/website/package.json
+++ b/website/package.json
@@ -6,10 +6,12 @@
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",
+		"test:seo": "pnpm build && node scripts/verify-seo-build.mjs",
 		"preview": "astro preview",
 		"check": "astro check"
 	},
 	"dependencies": {
+		"@astrojs/sitemap": "^3.7.3",
 		"@astrojs/starlight": "^0.41.5",
 		"@astrojs/svelte": "^9.0.1",
 		"@fontsource-variable/ibm-plex-sans": "^5.3.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.3
+        version: 3.7.3
       '@astrojs/starlight':
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,2 @@
+/docs  /docs/getting-started/introduction/  301
+/docs/ /docs/getting-started/introduction/  301

--- a/website/scripts/verify-seo-build.mjs
+++ b/website/scripts/verify-seo-build.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const redirects = await readFile(new URL('../dist/_redirects', import.meta.url), 'utf8');
+assert.match(
+	redirects,
+	/^\/docs\/?\s+\/docs\/getting-started\/introduction\/\s+301$/m,
+	'Cloudflare redirect for /docs/ is missing',
+);
+
+const home = await readFile(new URL('../dist/index.html', import.meta.url), 'utf8');
+assert.match(
+	home,
+	/href="\/docs\/getting-started\/introduction\/"/,
+	'the Docs navigation must link directly to the canonical page',
+);
+
+const sitemap = await readFile(new URL('../dist/sitemap-0.xml', import.meta.url), 'utf8');
+assert.doesNotMatch(
+	sitemap,
+	/<loc>https:\/\/useindelible\.com\/screens\/<\/loc>/,
+	'/screens/ must not be included in the sitemap',
+);
+assert.match(
+	sitemap,
+	/<loc>https:\/\/useindelible\.com\/docs\/getting-started\/introduction\/<\/loc>/,
+	'the canonical docs entry point must remain in the sitemap',
+);

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -32,7 +32,10 @@ export const NAV: readonly NavLink[] = [
  * it sits beside the CTA so it survives the width where the anchor list is
  * hidden. Before it existed the only route to the docs was the footer.
  */
-export const DOCS_LINK: NavLink = { label: 'Docs', href: '/docs/' };
+export const DOCS_LINK: NavLink = {
+	label: 'Docs',
+	href: '/docs/getting-started/introduction/',
+};
 
 /** The quick-start, verbatim from the self-hosting docs. */
 export const INSTALL_COMMANDS: readonly string[] = [


### PR DESCRIPTION
Non-i18n fixes that rode the localization branch: correct search indexing signals on the marketing site (redirects, canonical docs link, SEO build check) and use the Indelible mark as the web app favicon.