### PR TITLE
fix(ingest): decode PDF text strings per ISO 32000-2

### DIFF
--- a/backend/crates/ind-ingest/src/file_upload.rs
+++ b/backend/crates/ind-ingest/src/file_upload.rs
@@ -506,9 +506,12 @@ fn extract_pdf_metadata(data: &[u8]) -> ExtractedMetadata {
     meta
 }
 
+/// PDF text strings are UTF-16 with a BOM or PDFDocEncoding (ISO 32000-2
+/// §7.9.2); `pdf_oxide` hands them back undecoded. Reading them as UTF-8
+/// turns a UTF-16BE title into a string interleaved with NULs.
 fn pdf_object_to_string(obj: &pdf_oxide::object::Object) -> Option<String> {
     obj.as_string()
-        .map(String::from_utf8_lossy)
+        .map(pdf_oxide::optional_content::decode_pdf_text_string)
         .map(|value| value.trim().to_string())
         .and_then(non_empty_string)
 }

--- a/backend/crates/ind-ingest/tests/file_upload_journey.rs
+++ b/backend/crates/ind-ingest/tests/file_upload_journey.rs
@@ -349,3 +349,108 @@ fn unsupported_pdf_encryption_is_not_reported_as_password_protection() {
         "unexpected error: {error:?}"
     );
 }
+
+/// Minimal single-page PDF whose Info dictionary carries `raw_title` verbatim,
+/// written as a hex string. `DocumentBuilder::title` re-encodes whatever it is
+/// given, so a hand-written file is the only way to control the exact bytes a
+/// reader sees for `/Title`.
+fn pdf_with_raw_info_title(raw_title: &[u8]) -> Vec<u8> {
+    let hex: String = raw_title.iter().map(|byte| format!("{byte:02X}")).collect();
+    let objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>".to_string(),
+        format!("<< /Title <{hex}> >>"),
+    ];
+
+    let mut pdf = Vec::from("%PDF-1.7\n");
+    let mut offsets = Vec::with_capacity(objects.len());
+    for (index, body) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+
+    // The xref table indexes byte offsets of every object, so it can only be
+    // written once the bodies above are laid out.
+    let startxref = pdf.len();
+    let size = objects.len() + 1;
+    pdf.extend_from_slice(format!("xref\n0 {size}\n0000000000 65535 f \n").as_bytes());
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {size} /Root 1 0 R /Info 4 0 R >>\nstartxref\n{startxref}\n%%EOF\n"
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn utf16be(text: &str) -> Vec<u8> {
+    let mut out = vec![0xFE_u8, 0xFF];
+    for unit in text.encode_utf16() {
+        out.extend_from_slice(&unit.to_be_bytes());
+    }
+    out
+}
+
+fn utf16le(text: &str) -> Vec<u8> {
+    let mut out = vec![0xFF_u8, 0xFE];
+    for unit in text.encode_utf16() {
+        out.extend_from_slice(&unit.to_le_bytes());
+    }
+    out
+}
+
+async fn title_of(raw_info_title: &[u8]) -> String {
+    DocumentFileUploadProcessor
+        .process_upload(request(
+            "book.pdf",
+            "application/pdf",
+            pdf_with_raw_info_title(raw_info_title),
+            10 * 1024 * 1024,
+        ))
+        .await
+        .unwrap()
+        .title
+}
+
+#[tokio::test]
+async fn pdf_utf16be_title_decodes_without_nul_bytes() {
+    let expected = "System Design Interview An Insider\u{2019}s Guide";
+    let title = title_of(&utf16be(expected)).await;
+    assert!(
+        !title.contains('\0'),
+        "NUL would be rejected by Postgres: {title:?}"
+    );
+    assert_eq!(title, expected);
+}
+
+#[tokio::test]
+async fn pdf_utf16le_title_decodes() {
+    let expected = "Designing Data\u{2011}Intensive Applications";
+    assert_eq!(title_of(&utf16le(expected)).await, expected);
+}
+
+#[tokio::test]
+async fn pdf_pdfdocencoding_punctuation_decodes() {
+    // 0x84 is EM DASH in PDFDocEncoding. As a lone byte it is invalid UTF-8,
+    // so reading the string as UTF-8 turns it into U+FFFD.
+    let raw = b"Clean Code \x84 A Handbook";
+    assert_eq!(title_of(raw).await, "Clean Code \u{2014} A Handbook");
+}
+
+#[tokio::test]
+async fn pdf_ascii_title_still_round_trips() {
+    let expected = "Cracking the Coding Interview";
+    assert_eq!(title_of(expected.as_bytes()).await, expected);
+}
+
+#[tokio::test]
+async fn pdf_raw_utf8_title_is_accepted_leniently() {
+    // Spec-violating but common in the wild: UTF-8 bytes with no BOM. The
+    // crate decoder tries UTF-8 before falling back to PDFDocEncoding.
+    let expected = "Caf\u{e9} Culture";
+    assert_eq!(title_of(expected.as_bytes()).await, expected);
+}


### PR DESCRIPTION
- PDF Info-dict title/author are PDF text strings (PDFDocEncoding or BOM-prefixed UTF-16); `pdf_object_to_string` read the raw bytes as UTF-8, so UTF-16 titles became NUL-interleaved strings and Postgres rejected the insert with a 500
- decode via `pdf_oxide::optional_content::decode_pdf_text_string` instead
- adds a hand-written PDF fixture with raw Info /Title bytes; regression tests for UTF-16BE, UTF-16LE, PDFDocEncoding 0x84 em dash, ASCII, and lenient raw UTF-8
- fixes the production `invalid byte sequence for encoding "UTF8": 0x00` on `POST /api/v1/library/uploads`