### PR TITLE
fix(persistence): strip NUL from document text fields

### DIFF
--- a/backend/crates/ind-application/src/text.rs
+++ b/backend/crates/ind-application/src/text.rs
@@ -130,6 +130,11 @@ pub fn normalize_text(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// Postgres `text` rejects NUL (`0x00`); everything else it stores as-is.
+pub fn strip_nul(value: &str) -> String {
+    value.replace('\0', "")
+}
+
 fn split_sentences(text: &str) -> Vec<String> {
     let mut sentences = Vec::new();
     let mut sentence_start = 0_usize;
@@ -161,5 +166,19 @@ fn split_sentences(text: &str) -> Vec<String> {
         vec![text.trim().to_string()]
     } else {
         sentences
+    }
+}
+
+#[cfg(test)]
+mod strip_nul_tests {
+    use super::strip_nul;
+
+    #[test]
+    fn removes_nul_and_nothing_else() {
+        assert_eq!(strip_nul("Insider\u{0}s Guide"), "Insiders Guide");
+        assert_eq!(
+            strip_nul("a\tb\nc \u{2019} \u{e9}"),
+            "a\tb\nc \u{2019} \u{e9}"
+        );
     }
 }

--- a/backend/crates/ind-persistence/src/repos/document_repo/tx_writes.rs
+++ b/backend/crates/ind-persistence/src/repos/document_repo/tx_writes.rs
@@ -7,7 +7,7 @@
 //! are thin wrappers over these. See docs/document-feed-library-architecture.md
 //! (Materialization and adoption must be atomic).
 
-use ind_application::{AppError, normalize_language_tag};
+use ind_application::{AppError, normalize_language_tag, text::strip_nul};
 use ind_domain::{
     DocumentId, DocumentOriginType, DomainError, EmailSenderId, NewOriginDocument, NewUrlDocument,
     UserId,
@@ -27,6 +27,9 @@ pub(crate) async fn materialize_url_backed_tx(
     doc: &NewUrlDocument,
 ) -> Result<(DocumentRow, bool), AppError> {
     let language = normalize_language_tag(doc.language.as_deref());
+    let title = strip_nul(&doc.title);
+    let author = doc.author.as_deref().map(strip_nul);
+    let excerpt = doc.excerpt.as_deref().map(strip_nul);
     let inserted = sqlx::query_as!(
         DocumentRow,
         "INSERT INTO documents \
@@ -44,9 +47,9 @@ pub(crate) async fn materialize_url_backed_tx(
         doc.canonical_url,
         doc.original_url,
         doc.content_hash,
-        doc.title,
-        doc.author,
-        doc.excerpt,
+        title,
+        author,
+        excerpt,
         doc.published_at,
         language,
         doc.domain,
@@ -95,6 +98,9 @@ pub(crate) async fn materialize_origin_backed_tx(
     }
 
     let language = normalize_language_tag(doc.language.as_deref());
+    let title = strip_nul(&doc.title);
+    let author = doc.author.as_deref().map(strip_nul);
+    let excerpt = doc.excerpt.as_deref().map(strip_nul);
     let mut sp = tx.begin().await.map_err(map_document_error)?;
     // `document_created` tracks whether THIS call inserted the document, distinct from
     // whether it claimed the origin: a content-hash hit reuses an existing document and
@@ -116,9 +122,9 @@ pub(crate) async fn materialize_origin_backed_tx(
             doc.document_type.as_str(),
             doc.content_hash,
             doc.original_url,
-            doc.title,
-            doc.author,
-            doc.excerpt,
+            title,
+            author,
+            excerpt,
             doc.published_at,
             language,
             doc.domain,
@@ -164,9 +170,9 @@ pub(crate) async fn materialize_origin_backed_tx(
             doc.document_type.as_str(),
             doc.content_hash,
             doc.original_url,
-            doc.title,
-            doc.author,
-            doc.excerpt,
+            title,
+            author,
+            excerpt,
             doc.published_at,
             language,
             doc.domain,

--- a/backend/crates/ind-persistence/src/repos/document_repo/writes.rs
+++ b/backend/crates/ind-persistence/src/repos/document_repo/writes.rs
@@ -1,5 +1,5 @@
 use ind_application::repos::document::{DocumentRenderedMetadata, DocumentYoutubeEnrichment};
-use ind_application::{AppError, normalize_language_tag};
+use ind_application::{AppError, normalize_language_tag, text::strip_nul};
 use ind_domain::{
     Document, DocumentId, DocumentOriginType, DomainError, NewOriginDocument, NewUrlDocument,
     UserId,
@@ -41,6 +41,9 @@ impl PgDocumentRepository {
         document_id: DocumentId,
         metadata: DocumentRenderedMetadata,
     ) -> Result<(), AppError> {
+        let title = metadata.title.as_deref().map(strip_nul);
+        let author = metadata.author.as_deref().map(strip_nul);
+        let excerpt = metadata.excerpt.as_deref().map(strip_nul);
         sqlx::query!(
             r#"UPDATE documents
                SET title = CASE
@@ -55,9 +58,9 @@ impl PgDocumentRepository {
                WHERE id = $1 AND user_id = $2"#,
             document_id.into_uuid(),
             user_id.into_uuid(),
-            metadata.title,
-            metadata.author,
-            metadata.excerpt,
+            title,
+            author,
+            excerpt,
         )
         .execute(&self.pool)
         .await
@@ -174,6 +177,8 @@ impl PgDocumentRepository {
         document_id: DocumentId,
         enrichment: DocumentYoutubeEnrichment,
     ) -> Result<(), AppError> {
+        let title = enrichment.title.as_deref().map(strip_nul);
+        let excerpt = enrichment.excerpt.as_deref().map(strip_nul);
         let mut tx = self.pool.begin().await.map_err(map_document_error)?;
 
         let result = sqlx::query!(
@@ -186,8 +191,8 @@ impl PgDocumentRepository {
                WHERE id = $1 AND user_id = $2"#,
             document_id.into_uuid(),
             user_id.into_uuid(),
-            enrichment.title,
-            enrichment.excerpt,
+            title,
+            excerpt,
             enrichment.lead_image_url,
         )
         .execute(&mut *tx)

--- a/backend/crates/ind-persistence/tests/document_lifecycle_tests.rs
+++ b/backend/crates/ind-persistence/tests/document_lifecycle_tests.rs
@@ -3,14 +3,14 @@
 use chrono::Utc;
 use ind_application::handlers::feed_identity::feed_entry_identity;
 use ind_application::repos::document_lifecycle::{
-    DocumentLifecycle, DocumentStateInput, MaterializeIdentity, MaterializeRequest,
-    MaterializeSideEffects, SaveToLibraryRequest,
+    DocumentLifecycle, DocumentStateInput, MaterializeIdentity, MaterializeOrigin,
+    MaterializeRequest, MaterializeSideEffects, SaveToLibraryRequest,
 };
 use ind_application::repos::feed::FeedRepository;
 use ind_application::repos::lifecycle_outbox::OutboxEntry;
 use ind_domain::{
-    ContentSource, DocumentId, DocumentType, FeedSourceEntry, FeedSourceEntryId, NewUrlDocument,
-    build_domain_event,
+    ContentSource, DocumentId, DocumentOriginType, DocumentType, FeedSourceEntry,
+    FeedSourceEntryId, NewOriginDocument, NewUrlDocument, build_domain_event,
 };
 use ind_persistence::repos::{PgDocumentLifecycle, PgFeedRepository};
 use ind_test_support::{
@@ -236,4 +236,51 @@ async fn origin_backed_feed_entries_adopt_deliveries_during_materialize_and_save
         (1, 1)
     );
     assert_eq!(saved.entry.document_id, saved.document.id);
+}
+
+/// Mirrors what an undecoded UTF-16BE PDF title used to produce: a NUL-bearing title reaching
+/// the content-hash INSERT variant (the upload path) made Postgres reject the whole transaction
+/// with `invalid byte sequence for encoding "UTF8": 0x00`.
+#[tokio::test]
+async fn materialize_strips_nul_from_title_instead_of_failing() {
+    let db = TestDb::new().await;
+    let pool = db.pool().clone();
+    let user = UserFactory::default().insert(&pool).await;
+
+    let materialized = PgDocumentLifecycle::new(pool.clone())
+        .materialize_document(MaterializeRequest {
+            identity: MaterializeIdentity::Origin {
+                document: NewOriginDocument {
+                    id: DocumentId::new(),
+                    user_id: user.id,
+                    document_type: DocumentType::Pdf,
+                    content_hash: Some(uuid::Uuid::now_v7().simple().to_string()),
+                    original_url: None,
+                    title: "Insider\u{0}s Guide".into(),
+                    author: Some("Alex\u{0} Xu".into()),
+                    excerpt: Some("Chapter\u{0} one".into()),
+                    published_at: None,
+                    language: None,
+                    domain: None,
+                    lead_image_url: None,
+                    thumbnail_url: None,
+                    sender_id: None,
+                },
+                origin: MaterializeOrigin {
+                    origin_type: DocumentOriginType::ManualUpload,
+                    origin_id: uuid::Uuid::now_v7(),
+                },
+            },
+            document_state: None,
+            side_effects: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(materialized.document.title, "Insiders Guide");
+    assert_eq!(materialized.document.author.as_deref(), Some("Alex Xu"));
+    assert_eq!(
+        materialized.document.excerpt.as_deref(),
+        Some("Chapter one")
+    );
 }


### PR DESCRIPTION
- Postgres `text` rejects NUL (`0x00`); externally-derived titles/authors (email subjects, EPUB metadata, renderer extraction) reach the document INSERT/UPDATE paths unsanitized
- adds `strip_nul` in `ind-application::text` and applies it at the 5 title/author/excerpt bind sites (3 inserts in `tx_writes.rs`, 2 updates in `writes.rs`), mirroring how `normalize_language_tag` is applied
- DB regression test reproduces the production `invalid byte sequence for encoding "UTF8": 0x00` on the content-hash INSERT (the upload path) pre-fix
- feed entry writes (`feed_repo/entries.rs`) are a separate path, addressed in a follow-up PR