### PR TITLE
fix(web): localize the oversized-upload error

### DIFF
--- a/web/src/lib/api/uploads.ts
+++ b/web/src/lib/api/uploads.ts
@@ -1,6 +1,8 @@
 import { getAccessToken } from '$lib/auth-tokens';
 import { getApiBaseUrl } from '$lib/api/client';
+import { getMaxUploadBytes, resetUploadLimitsCache } from '$lib/api/upload-limits';
 import type { LibraryEntryResponse } from '$lib/api/generated/types.gen';
+import { formatMegabytes } from '$lib/format/megabytes';
 import { get } from 'svelte/store';
 import { t } from '$lib/i18n';
 
@@ -55,7 +57,25 @@ export function uploadLibraryFile(
 			});
 		};
 
-		xhr.onload = () => {
+		xhr.onload = async () => {
+			// A 413 can still reach us: the limit lookup failed, the server lowered it
+			// after the page loaded, or the body tripped axum's own DefaultBodyLimit —
+			// whose plain-text response would otherwise render as "Upload failed (413)".
+			if (xhr.status === 413) {
+				// The 413 proves any memoised limit is stale or missing, so drop it before re-asking.
+				resetUploadLimitsCache();
+				// A rejection here would hang the upload promise forever, so degrade to the generic message.
+				const limit = await getMaxUploadBytes().catch(() => null);
+				resolve({
+					success: false,
+					error:
+						limit !== null
+							? get(t)('library_upload_too_large', { values: { size: formatMegabytes(limit) } })
+							: get(t)('library_upload_too_large_generic')
+				});
+				return;
+			}
+
 			const body = parseJson(xhr.responseText);
 			if (xhr.status >= 200 && xhr.status < 300) {
 				resolve({ success: true, data: body as LibraryEntryResponse });

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -1089,6 +1089,7 @@
 	"library_upload_network_error": "Network error during upload",
 	"library_upload_supported_formats": "PDF, EPUB, HTML",
 	"library_upload_too_large": "File is too large. Maximum size is {size} MB.",
+	"library_upload_too_large_generic": "File is too large for this server.",
 	"library_upload_unsupported_type": "Unsupported type. Allowed: {types}",
 	"library_upload_upload": "Upload",
 	"library_upload_uploading": "Uploading",

--- a/web/src/lib/i18n/locales/fr.json
+++ b/web/src/lib/i18n/locales/fr.json
@@ -1089,6 +1089,7 @@
 	"library_upload_network_error": "Erreur réseau pendant l’import",
 	"library_upload_supported_formats": "PDF, EPUB, HTML",
 	"library_upload_too_large": "Le fichier est trop volumineux. La taille maximale est de {size} Mo.",
+	"library_upload_too_large_generic": "Le fichier est trop volumineux pour ce serveur.",
 	"library_upload_unsupported_type": "Type non pris en charge. Types autorisés : {types}",
 	"library_upload_upload": "Importer",
 	"library_upload_uploading": "Importation",

--- a/web/tests/uploads.test.ts
+++ b/web/tests/uploads.test.ts
@@ -1,5 +1,14 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { uploadLibraryFile } from '$lib/api/uploads';
+import { getMaxUploadBytes, resetUploadLimitsCache } from '$lib/api/upload-limits';
+
+vi.mock('$lib/api/upload-limits', () => ({
+	getMaxUploadBytes: vi.fn(),
+	resetUploadLimitsCache: vi.fn()
+}));
+
+const getMaxUploadBytesMock = vi.mocked(getMaxUploadBytes);
+const resetUploadLimitsCacheMock = vi.mocked(resetUploadLimitsCache);
 
 class FakeXmlHttpRequest {
 	static responseStatus = 422;
@@ -22,7 +31,17 @@ class FakeXmlHttpRequest {
 	}
 }
 
+const pdf = () => new File(['%PDF-1.7'], 'book.pdf', { type: 'application/pdf' });
+
 describe('uploadLibraryFile', () => {
+	beforeEach(() => {
+		FakeXmlHttpRequest.responseStatus = 422;
+		FakeXmlHttpRequest.responseText = '';
+		getMaxUploadBytesMock.mockReset();
+		getMaxUploadBytesMock.mockResolvedValue(null);
+		resetUploadLimitsCacheMock.mockReset();
+	});
+
 	afterEach(() => {
 		vi.unstubAllGlobals();
 	});
@@ -42,5 +61,85 @@ describe('uploadLibraryFile', () => {
 			success: false,
 			error: 'Password-protected PDFs are not supported.'
 		});
+	});
+
+	it('localizes a 413 with the server limit when the lookup succeeds', async () => {
+		getMaxUploadBytesMock.mockResolvedValue(50 * 1024 * 1024);
+		FakeXmlHttpRequest.responseStatus = 413;
+		FakeXmlHttpRequest.responseText = JSON.stringify({ detail: 'payload too large' });
+		vi.stubGlobal('XMLHttpRequest', FakeXmlHttpRequest);
+
+		const result = await uploadLibraryFile(pdf());
+
+		expect(result).toEqual({
+			success: false,
+			error: 'File is too large. Maximum size is 50 MB.'
+		});
+	});
+
+	it('refetches the limit after a 413 instead of reusing the stale cached one', async () => {
+		// The modal cached 50 MB on open; the server has since lowered the cap to 10 MB.
+		let served = 50 * 1024 * 1024;
+		resetUploadLimitsCacheMock.mockImplementation(() => {
+			served = 10 * 1024 * 1024;
+		});
+		getMaxUploadBytesMock.mockImplementation(async () => served);
+		FakeXmlHttpRequest.responseStatus = 413;
+		FakeXmlHttpRequest.responseText = JSON.stringify({ detail: 'payload too large' });
+		vi.stubGlobal('XMLHttpRequest', FakeXmlHttpRequest);
+
+		const result = await uploadLibraryFile(pdf());
+
+		expect(result).toEqual({
+			success: false,
+			error: 'File is too large. Maximum size is 10 MB.'
+		});
+		expect(resetUploadLimitsCacheMock).toHaveBeenCalledTimes(1);
+		expect(resetUploadLimitsCacheMock.mock.invocationCallOrder[0]).toBeLessThan(
+			getMaxUploadBytesMock.mock.invocationCallOrder[0]
+		);
+	});
+
+	it('localizes a 413 whose body is plain text rather than JSON', async () => {
+		getMaxUploadBytesMock.mockResolvedValue(50 * 1024 * 1024);
+		FakeXmlHttpRequest.responseStatus = 413;
+		FakeXmlHttpRequest.responseText = 'length limit exceeded';
+		vi.stubGlobal('XMLHttpRequest', FakeXmlHttpRequest);
+
+		const result = await uploadLibraryFile(pdf());
+
+		expect(result).toEqual({
+			success: false,
+			error: 'File is too large. Maximum size is 50 MB.'
+		});
+	});
+
+	it('falls back to the generic message when the limit is unknown', async () => {
+		getMaxUploadBytesMock.mockResolvedValue(null);
+		FakeXmlHttpRequest.responseStatus = 413;
+		FakeXmlHttpRequest.responseText = JSON.stringify({ detail: 'payload too large' });
+		vi.stubGlobal('XMLHttpRequest', FakeXmlHttpRequest);
+
+		const result = await uploadLibraryFile(pdf());
+
+		expect(result).toEqual({
+			success: false,
+			error: 'File is too large for this server.'
+		});
+	});
+
+	it('leaves non-413 failures to the problem-detail message', async () => {
+		FakeXmlHttpRequest.responseStatus = 500;
+		FakeXmlHttpRequest.responseText = JSON.stringify({ detail: 'An unexpected error occurred' });
+		vi.stubGlobal('XMLHttpRequest', FakeXmlHttpRequest);
+
+		const result = await uploadLibraryFile(pdf());
+
+		expect(result).toEqual({
+			success: false,
+			error: 'An unexpected error occurred'
+		});
+		expect(getMaxUploadBytesMock).not.toHaveBeenCalled();
+		expect(resetUploadLimitsCacheMock).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
- a 413 is still reachable (limit lookup failed, limit lowered server-side, axum body-limit edge) and rendered the raw `payload too large` / `Upload failed (413)`
- 413 responses now render the localized sized message (identical to the modal pre-check) or a generic one when the limit is unknown; non-JSON 413 bodies covered
- 500s untouched (pinned by a control test)
- new key `library_upload_too_large_generic` (en+fr)
- stacked on #21; base retargets when it merges