### PR TITLE
fix(persistence): strip NUL from feed entry text fields

### DIFF
--- a/backend/crates/ind-persistence/src/repos/feed_repo/entries.rs
+++ b/backend/crates/ind-persistence/src/repos/feed_repo/entries.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use ind_application::{AppError, normalize_language_tag};
+use ind_application::{AppError, normalize_language_tag, text::strip_nul};
 use ind_domain::*;
 use uuid::Uuid;
 
@@ -42,6 +42,45 @@ impl From<SourceEntryRow> for FeedSourceEntry {
     }
 }
 
+/// Postgres `text` rejects NUL (`0x00`), and remote feeds occasionally carry one (a
+/// mis-decoded UTF-16 title being the usual source). Sanitizing the whole entry up front
+/// puts the write and the dedup comparisons on the same value, which matters twice over:
+/// a raw bind on either side fails the statement outright with
+/// `invalid byte sequence for encoding "UTF8": 0x00`, and sanitizing only one side would
+/// leave a stored entry unable to match the next poll's copy of it, duplicating it forever.
+fn strip_nul_from_entry_text(entry: &mut FeedSourceEntry) {
+    // Destructured field by field on purpose: a new column breaks this function until
+    // someone decides whether it needs sanitizing.
+    let FeedSourceEntry {
+        guid,
+        title,
+        url,
+        canonical_url,
+        author,
+        excerpt,
+        content_html,
+        language,
+        lead_image_url,
+        // Server-generated: identifiers and timestamps never carry remote bytes.
+        id: _,
+        source_id: _,
+        published_at: _,
+        discovered_at: _,
+    } = entry;
+
+    // Stripping is lossy: two remote guids differing only by a NUL collapse into one. That is
+    // acceptable because a stored guid can never contain a NUL for them to collide with.
+    *guid = strip_nul(guid);
+    *title = strip_nul(title);
+    *url = url.as_deref().map(strip_nul);
+    *canonical_url = canonical_url.as_deref().map(strip_nul);
+    *author = author.as_deref().map(strip_nul);
+    *excerpt = excerpt.as_deref().map(strip_nul);
+    *content_html = content_html.as_deref().map(strip_nul);
+    *language = language.as_deref().map(strip_nul);
+    *lead_image_url = lead_image_url.as_deref().map(strip_nul);
+}
+
 impl PgFeedRepository {
     pub(super) async fn set_source_entry_language_if_missing_impl(
         &self,
@@ -51,6 +90,8 @@ impl PgFeedRepository {
         let Some(language) = normalize_language_tag(Some(language)) else {
             return Ok(false);
         };
+        // Normalization lowercases and reshapes the tag but keeps any NUL the detector saw.
+        let language = strip_nul(&language);
         let result = sqlx::query!(
             "UPDATE feed_source_entries \
              SET language = $2 \
@@ -70,6 +111,9 @@ impl PgFeedRepository {
         source_id: FeedSourceId,
         guid: &str,
     ) -> Result<Option<FeedSourceEntry>, AppError> {
+        // The write strips NUL, so a stored guid is always NUL-free; the lookup has to strip
+        // the same way or a caller's raw guid would never match the row it stored.
+        let guid = strip_nul(guid);
         let row = sqlx::query_as!(
             SourceEntryRow,
             "SELECT id, source_id, guid, title, url, canonical_url, author, excerpt, content_html, language, \
@@ -110,6 +154,7 @@ impl PgFeedRepository {
         mut entry: FeedSourceEntry,
     ) -> Result<FeedSourceEntry, AppError> {
         entry.language = normalize_language_tag(entry.language.as_deref());
+        strip_nul_from_entry_text(&mut entry);
         let row = sqlx::query_as!(
             SourceEntryRow,
             "INSERT INTO feed_source_entries \
@@ -143,6 +188,7 @@ impl PgFeedRepository {
         mut entry: FeedSourceEntry,
     ) -> Result<FeedSourceEntry, AppError> {
         entry.language = normalize_language_tag(entry.language.as_deref());
+        strip_nul_from_entry_text(&mut entry);
         let mut tx = self.pool.begin().await.map_err(map_entry_error)?;
         let source_lock = entry.source_id.to_string();
         sqlx::query!(
@@ -262,6 +308,7 @@ impl PgFeedRepository {
         entry_id: FeedSourceEntryId,
         canonical_url: &str,
     ) -> Result<(), AppError> {
+        let canonical_url = strip_nul(canonical_url);
         sqlx::query!(
             "UPDATE feed_source_entries SET canonical_url = $1 WHERE id = $2",
             canonical_url,

--- a/backend/crates/ind-persistence/src/repos/feed_repo/sources.rs
+++ b/backend/crates/ind-persistence/src/repos/feed_repo/sources.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
-use ind_application::AppError;
+use ind_application::{AppError, text::strip_nul};
 use ind_domain::*;
 use uuid::Uuid;
 
@@ -70,6 +70,104 @@ impl TryFrom<SourceRow> for FeedSource {
     }
 }
 
+/// A feed source is a mirror of a remote document: its title, description, URLs and the
+/// HTTP validators all arrive verbatim from the network, and Postgres `text` rejects the NUL
+/// (`0x00`) a mis-decoded feed can carry. `canonical_key` is also the lookup key, so
+/// `find_source_by_canonical_key_impl` strips it the same way.
+fn strip_nul_from_source_text(source: &mut FeedSource) {
+    // Destructured field by field on purpose: a new column breaks this function until
+    // someone decides whether it needs sanitizing.
+    let FeedSource {
+        canonical_key,
+        source_url,
+        poll_url,
+        title,
+        description,
+        site_url,
+        image_url,
+        domain,
+        last_etag,
+        last_modified,
+        last_error,
+        // Server-controlled: identifiers, enums, counters, timestamps, the worker lease, and
+        // the provider slug we assign ourselves.
+        id: _,
+        feed_type: _,
+        visibility: _,
+        provider: _,
+        is_resolvable: _,
+        popularity: _,
+        last_entry_added_at: _,
+        last_polled_at: _,
+        next_poll_at: _,
+        consecutive_failures: _,
+        lease_owner: _,
+        lease_expires_at: _,
+        created_at: _,
+        updated_at: _,
+    } = source;
+
+    *canonical_key = strip_nul(canonical_key);
+    *source_url = strip_nul(source_url);
+    *poll_url = strip_nul(poll_url);
+    *title = strip_nul(title);
+    *description = description.as_deref().map(strip_nul);
+    *site_url = site_url.as_deref().map(strip_nul);
+    *image_url = image_url.as_deref().map(strip_nul);
+    *domain = domain.as_deref().map(strip_nul);
+    *last_etag = last_etag.as_deref().map(strip_nul);
+    *last_modified = last_modified.as_deref().map(strip_nul);
+    *last_error = last_error.as_deref().map(strip_nul);
+}
+
+/// The poll writers update the HTTP validators and the error text on their own, so they carry
+/// remote bytes into the same columns [`strip_nul_from_source_text`] guards at create time.
+fn strip_nul_from_poll_outcome(state: &mut PollOutcome) {
+    // Destructured field by field on purpose: a new column breaks this function until
+    // someone decides whether it needs sanitizing.
+    let PollOutcome {
+        last_etag,
+        last_modified,
+        last_error,
+        // Server-controlled: the source identifier, a counter, and timestamps.
+        source_id: _,
+        last_polled_at: _,
+        next_poll_at: _,
+        consecutive_failures: _,
+    } = state;
+
+    *last_etag = last_etag.as_deref().map(strip_nul);
+    *last_modified = last_modified.as_deref().map(strip_nul);
+    *last_error = last_error.as_deref().map(strip_nul);
+}
+
+/// Same remote metadata as [`strip_nul_from_source_text`], re-read on every refresh, so NUL
+/// can reappear long after the source was first created.
+fn strip_nul_from_source_details(details: &mut SourceDetailsUpdate) {
+    // Destructured field by field on purpose: a new column breaks this function until
+    // someone decides whether it needs sanitizing.
+    let SourceDetailsUpdate {
+        poll_url,
+        title,
+        description,
+        site_url,
+        image_url,
+        domain,
+        // Server-controlled: enums, the provider slug, and a bool.
+        feed_type: _,
+        visibility: _,
+        provider: _,
+        is_resolvable: _,
+    } = details;
+
+    *poll_url = strip_nul(poll_url);
+    *title = strip_nul(title);
+    *description = description.as_deref().map(strip_nul);
+    *site_url = site_url.as_deref().map(strip_nul);
+    *image_url = image_url.as_deref().map(strip_nul);
+    *domain = domain.as_deref().map(strip_nul);
+}
+
 impl PgFeedRepository {
     pub(super) async fn find_source_by_id_impl(
         &self,
@@ -96,6 +194,9 @@ impl PgFeedRepository {
         &self,
         canonical_key: &str,
     ) -> Result<Option<FeedSource>, AppError> {
+        // The write strips NUL, so a stored key is always NUL-free; the lookup has to strip
+        // the same way or a caller's raw key would never match the row it stored.
+        let canonical_key = strip_nul(canonical_key);
         let row = sqlx::query_as!(
             SourceRow,
             "SELECT id, canonical_key, source_url, poll_url, title, description, site_url, \
@@ -115,8 +216,9 @@ impl PgFeedRepository {
 
     pub(super) async fn create_source_impl(
         &self,
-        source: FeedSource,
+        mut source: FeedSource,
     ) -> Result<FeedSource, AppError> {
+        strip_nul_from_source_text(&mut source);
         let row = sqlx::query_as!(
             SourceRow,
             "INSERT INTO feed_sources \
@@ -168,8 +270,9 @@ impl PgFeedRepository {
     pub(super) async fn update_source_details_impl(
         &self,
         id: FeedSourceId,
-        details: ind_domain::SourceDetailsUpdate,
+        mut details: ind_domain::SourceDetailsUpdate,
     ) -> Result<FeedSource, AppError> {
+        strip_nul_from_source_details(&mut details);
         let row = sqlx::query_as!(
             SourceRow,
             "UPDATE feed_sources \
@@ -273,9 +376,10 @@ impl PgFeedRepository {
     pub(super) async fn mark_source_poll_success_impl(
         &self,
         id: FeedSourceId,
-        state: PollOutcome,
+        mut state: PollOutcome,
         last_entry_added_at: Option<DateTime<Utc>>,
     ) -> Result<FeedSource, AppError> {
+        strip_nul_from_poll_outcome(&mut state);
         let row = sqlx::query_as!(
             SourceRow,
             "UPDATE feed_sources \
@@ -315,6 +419,9 @@ impl PgFeedRepository {
         error: String,
         consecutive_failures: i32,
     ) -> Result<FeedSource, AppError> {
+        // Poll failures quote what the remote sent — a URL, a parser message, a response
+        // fragment — so a NUL from the network can reach this column.
+        let error = strip_nul(&error);
         let row = sqlx::query_as!(
             SourceRow,
             "UPDATE feed_sources \

--- a/backend/crates/ind-persistence/tests/feed_text_sanitization_tests.rs
+++ b/backend/crates/ind-persistence/tests/feed_text_sanitization_tests.rs
@@ -1,0 +1,228 @@
+#![allow(clippy::unwrap_used)]
+
+use chrono::Utc;
+use ind_application::repos::feed::FeedRepository;
+use ind_domain::{
+    FeedSource, FeedSourceEntry, FeedSourceEntryId, FeedSourceId, FeedType, FeedVisibility,
+    PollOutcome,
+};
+use ind_persistence::repos::PgFeedRepository;
+use ind_test_support::{FeedSourceFactory, TestDb};
+
+/// Remote feeds can carry a NUL byte in any of their text fields (a mis-decoded UTF-16 title
+/// is the usual source), and Postgres `text` rejects `0x00` outright, so an unsanitized bind
+/// fails the whole statement with `invalid byte sequence for encoding "UTF8": 0x00`.
+///
+/// Sanitizing has to cover the read and comparison sides too, and for two distinct reasons:
+/// a raw bind in a `WHERE` clause hits the very same encoding error, and a predicate that
+/// sanitized *differently* from the write would silently stop matching the row it stored —
+/// so the polled path would re-insert the same entry on every poll instead of adopting it.
+#[tokio::test]
+async fn source_entry_writes_and_lookups_strip_nul_from_text_fields() {
+    let db = TestDb::new().await;
+    let pool = db.pool().clone();
+    let source = FeedSourceFactory.insert(&pool).await;
+    let feeds = PgFeedRepository::new(pool.clone());
+
+    // A guid that is a valid UUID once the NUL is stripped, so the polled path below can
+    // still recognize it as an adoptable entry.
+    let clean_guid = uuid::Uuid::now_v7().to_string();
+    let raw_guid = clean_guid.replacen('-', "\u{0}-", 1);
+    let title = "Break\u{0}ing News";
+    let author = Some("Ada\u{0} Lovelace".to_string());
+    let excerpt = Some("First\u{0} paragraph".to_string());
+    let content_html = Some("<p>Body\u{0} text</p>".to_string());
+    let url = Some("https://example.com/break\u{0}ing".to_string());
+
+    let seeded = feeds
+        .create_source_entry(FeedSourceEntry {
+            id: FeedSourceEntryId::new(),
+            source_id: source.id,
+            guid: raw_guid.clone(),
+            title: title.into(),
+            url: url.clone(),
+            canonical_url: None,
+            author: author.clone(),
+            excerpt: excerpt.clone(),
+            content_html: content_html.clone(),
+            language: None,
+            lead_image_url: None,
+            published_at: None,
+            discovered_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(seeded.guid, clean_guid);
+    assert_eq!(seeded.title, "Breaking News");
+    assert_eq!(seeded.author.as_deref(), Some("Ada Lovelace"));
+    assert_eq!(seeded.excerpt.as_deref(), Some("First paragraph"));
+    assert_eq!(seeded.content_html.as_deref(), Some("<p>Body text</p>"));
+    assert_eq!(seeded.url.as_deref(), Some("https://example.com/breaking"));
+
+    // The caller still holds the raw guid the feed gave it, and must find the row anyway.
+    let found = feeds
+        .find_source_entry_by_source_guid(source.id, &raw_guid)
+        .await
+        .unwrap()
+        .expect("raw NUL-bearing guid should find the sanitized row");
+    assert_eq!(found.id, seeded.id);
+
+    // The polled path adopts the stored row rather than duplicating it, which only works if
+    // its dedup predicate compares the same sanitized text the insert wrote.
+    let polled = feeds
+        .create_or_adopt_polled_source_entry(FeedSourceEntry {
+            id: FeedSourceEntryId::new(),
+            source_id: source.id,
+            guid: format!("entry-content-{}", uuid::Uuid::now_v7().simple()),
+            title: title.into(),
+            url,
+            canonical_url: Some("https://example.com/canon\u{0}ical".to_string()),
+            author,
+            excerpt,
+            content_html,
+            language: None,
+            lead_image_url: Some("https://example.com/lead\u{0}.png".to_string()),
+            published_at: None,
+            discovered_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        polled.id, seeded.id,
+        "polled entry should adopt the stored twin"
+    );
+    assert_eq!(polled.title, "Breaking News");
+    assert_eq!(polled.author.as_deref(), Some("Ada Lovelace"));
+    assert_eq!(polled.content_html.as_deref(), Some("<p>Body text</p>"));
+    assert_eq!(
+        polled.canonical_url.as_deref(),
+        Some("https://example.com/canonical")
+    );
+    assert_eq!(
+        polled.lead_image_url.as_deref(),
+        Some("https://example.com/lead.png")
+    );
+
+    // The canonicalization backfill writes the URL on its own, outside the entry write.
+    feeds
+        .set_source_entry_canonical_url(seeded.id, "https://example.com/back\u{0}fill")
+        .await
+        .unwrap();
+    let backfilled = feeds
+        .find_source_entry_by_id(seeded.id)
+        .await
+        .unwrap()
+        .expect("entry should still exist");
+    assert_eq!(
+        backfilled.canonical_url.as_deref(),
+        Some("https://example.com/backfill")
+    );
+}
+
+/// The feed's own metadata is remote text too, and `canonical_key` doubles as the lookup key
+/// for subscribe-time dedup, so it has to be sanitized on both sides like an entry guid.
+#[tokio::test]
+async fn source_writes_and_lookups_strip_nul_from_text_fields() {
+    let db = TestDb::new().await;
+    let pool = db.pool().clone();
+    let feeds = PgFeedRepository::new(pool.clone());
+
+    let poll_url = format!("https://{}.example.com/fe\u{0}ed.xml", uuid::Uuid::now_v7());
+    let canonical_key = format!("public:url:{poll_url}");
+    let timestamp = Utc::now();
+
+    let created = feeds
+        .create_source(FeedSource {
+            id: FeedSourceId::new(),
+            canonical_key: canonical_key.clone(),
+            source_url: poll_url.clone(),
+            poll_url: poll_url.clone(),
+            title: "Daily\u{0} Dispatch".into(),
+            description: Some("All the\u{0} news".to_string()),
+            site_url: Some("https://example.com/si\u{0}te".to_string()),
+            image_url: Some("https://example.com/lo\u{0}go.png".to_string()),
+            domain: Some("exa\u{0}mple.com".to_string()),
+            feed_type: FeedType::Rss,
+            visibility: FeedVisibility::Public,
+            provider: None,
+            is_resolvable: false,
+            popularity: 0,
+            last_entry_added_at: None,
+            last_polled_at: None,
+            next_poll_at: None,
+            last_etag: Some("W/\"eta\u{0}g\"".to_string()),
+            last_modified: None,
+            consecutive_failures: 0,
+            last_error: None,
+            lease_owner: None,
+            lease_expires_at: None,
+            created_at: timestamp,
+            updated_at: timestamp,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(created.title, "Daily Dispatch");
+    assert_eq!(created.description.as_deref(), Some("All the news"));
+    assert_eq!(
+        created.site_url.as_deref(),
+        Some("https://example.com/site")
+    );
+    assert_eq!(
+        created.image_url.as_deref(),
+        Some("https://example.com/logo.png")
+    );
+    assert_eq!(created.domain.as_deref(), Some("example.com"));
+    assert_eq!(created.last_etag.as_deref(), Some("W/\"etag\""));
+    assert_eq!(created.canonical_key, canonical_key.replace('\u{0}', ""));
+
+    // Resolving a feed URL hands the raw key back to the repository; it must still match.
+    let found = feeds
+        .find_source_by_canonical_key(&canonical_key)
+        .await
+        .unwrap()
+        .expect("raw NUL-bearing canonical key should find the sanitized row");
+    assert_eq!(found.id, created.id);
+
+    // Every poll rewrites the HTTP validators from the response headers, long after create.
+    let polled = feeds
+        .mark_source_poll_success(
+            created.id,
+            PollOutcome {
+                source_id: created.id,
+                last_polled_at: Some(timestamp),
+                next_poll_at: Some(timestamp),
+                last_etag: Some("W/\"fre\u{0}sh\"".to_string()),
+                last_modified: Some("Mon, 24 Aug 2026 00:00:00\u{0} GMT".to_string()),
+                consecutive_failures: 0,
+                last_error: None,
+            },
+            Some(timestamp),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(polled.last_etag.as_deref(), Some("W/\"fresh\""));
+    assert_eq!(
+        polled.last_modified.as_deref(),
+        Some("Mon, 24 Aug 2026 00:00:00 GMT")
+    );
+
+    // A failure message quotes what the remote sent, so it carries remote bytes too.
+    let failed = feeds
+        .mark_source_poll_failure(
+            created.id,
+            timestamp,
+            "parse error at \u{0} byte 12".to_string(),
+            1,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        failed.last_error.as_deref(),
+        Some("parse error at  byte 12")
+    );
+}


### PR DESCRIPTION
- feed entries and sources are written outside the document bind sites, so a NUL in remote feed text (title, author, excerpt, content_html, guid, urls, language, etag headers) still failed the INSERT/UPDATE with `invalid byte sequence for encoding "UTF8": 0x00`
- exhaustive struct-destructure helpers strip NUL before every write AND every dedup/lookup predicate, so a new column is a compile error until sanitization is decided
- lookups strip the probe value the same way (stored values can never contain NUL), keeping adopt/dedup consistent
- live poll writers (`mark_source_poll_success/failure`) covered, not just the create path
- DB regression tests reproduce the production 22021 pre-fix and pin write+predicate parity, per-writer, via mutation-checked coverage
- stacked on #19 (consumes `strip_nul`); base retargets when it merges