### PR TITLE
fix(mobile): cap picked file size before reading into memory

### DIFF
--- a/mobile/composeApp/src/androidMain/kotlin/app/indelible/core/platform/FilePicker.kt
+++ b/mobile/composeApp/src/androidMain/kotlin/app/indelible/core/platform/FilePicker.kt
@@ -1,14 +1,25 @@
 package app.indelible.core.platform
 
+import android.content.ContentResolver
+import android.content.res.AssetFileDescriptor
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+private const val DEFAULT_FILE_NAME = "import.opml"
+private const val UNKNOWN_SIZE = -1L
+private const val READ_CHUNK_BYTES = 8 * 1024
 
 @Composable
 actual fun rememberFilePicker(
     mimeTypes: List<String>,
+    maxBytes: Long,
+    onFileTooLarge: (name: String) -> Unit,
     onFilePicked: (bytes: ByteArray, name: String) -> Unit,
 ): () -> Unit {
     val context = LocalContext.current
@@ -17,12 +28,53 @@ actual fun rememberFilePicker(
             ActivityResultContracts.OpenDocument(),
         ) { uri: Uri? ->
             if (uri != null) {
-                val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-                if (bytes != null) {
-                    val name = uri.lastPathSegment?.substringAfterLast('/') ?: "import.opml"
-                    onFilePicked(bytes, name)
+                val resolver = context.contentResolver
+                val name = uri.lastPathSegment?.substringAfterLast('/') ?: DEFAULT_FILE_NAME
+                val declaredSize = resolver.pickedFileSize(uri)
+                if (declaredSize > maxBytes) {
+                    onFileTooLarge(name)
+                } else {
+                    // Providers may report no size at all, and a provider that
+                    // reports one can still stream more, so the read itself is
+                    // bounded: one byte past the cap is enough to reject.
+                    val bytes = resolver.openInputStream(uri)?.use { it.readAtMost(maxBytes + 1) }
+                    when {
+                        bytes == null -> Unit
+                        bytes.size > maxBytes -> onFileTooLarge(name)
+                        else -> onFilePicked(bytes, name)
+                    }
                 }
             }
         }
     return { launcher.launch(mimeTypes.toTypedArray()) }
+}
+
+/** Returns the picked file's size in bytes, or [UNKNOWN_SIZE] when the provider does not expose one. */
+private fun ContentResolver.pickedFileSize(uri: Uri): Long {
+    runCatching {
+        query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+            val column = cursor.getColumnIndex(OpenableColumns.SIZE)
+            if (column >= 0 && cursor.moveToFirst() && !cursor.isNull(column)) {
+                return cursor.getLong(column)
+            }
+        }
+    }
+    return runCatching { openAssetFileDescriptor(uri, "r")?.use { it.length } }
+        .getOrNull()
+        ?.takeIf { it != AssetFileDescriptor.UNKNOWN_LENGTH }
+        ?: UNKNOWN_SIZE
+}
+
+private fun InputStream.readAtMost(limit: Long): ByteArray {
+    val collected = ByteArrayOutputStream()
+    val chunk = ByteArray(READ_CHUNK_BYTES)
+    var total = 0L
+    while (total < limit) {
+        val wanted = minOf(chunk.size.toLong(), limit - total).toInt()
+        val read = read(chunk, 0, wanted)
+        if (read == -1) break
+        collected.write(chunk, 0, read)
+        total += read
+    }
+    return collected.toByteArray()
 }

--- a/mobile/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -151,6 +151,7 @@
     <string name="feed_empty_unseen_kicker">Vous êtes à jour</string>
     <string name="feed_empty_unseen_title">Aucun article non vu</string>
     <string name="feed_error_delete">Impossible de supprimer l’abonnement. Veuillez réessayer.</string>
+    <string name="feed_error_file_too_large">« %1$s » est trop volumineux pour être importé. Choisissez un fichier OPML plus petit.</string>
     <string name="feed_error_import_opml">Impossible d’importer le fichier OPML. Veuillez réessayer.</string>
     <string name="feed_error_load">Impossible de charger les flux. Veuillez réessayer.</string>
     <string name="feed_error_load_more">Impossible de charger plus de contenus. Veuillez réessayer.</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="feed_empty_unseen_kicker">You’re up to date</string>
     <string name="feed_empty_unseen_title">No unseen posts</string>
     <string name="feed_error_delete">Couldn’t delete the subscription. Please try again.</string>
+    <string name="feed_error_file_too_large">“%1$s” is too large to import. Choose a smaller OPML file.</string>
     <string name="feed_error_import_opml">Couldn’t import the OPML file. Please try again.</string>
     <string name="feed_error_load">Couldn’t load the feed. Please try again.</string>
     <string name="feed_error_load_more">Couldn’t load more feed items. Please try again.</string>

--- a/mobile/composeApp/src/commonMain/kotlin/app/indelible/core/platform/FilePicker.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/app/indelible/core/platform/FilePicker.kt
@@ -2,8 +2,18 @@ package app.indelible.core.platform
 
 import androidx.compose.runtime.Composable
 
+/**
+ * Picks a single file and hands its bytes to [onFilePicked].
+ *
+ * Every implementation determines the file's size before reading it, and where a
+ * platform cannot report a size the read itself is bounded, so a pick never puts
+ * more than [maxBytes] + 1 bytes in memory. Anything larger than [maxBytes] is
+ * reported through [onFileTooLarge] and never handed to [onFilePicked].
+ */
 @Composable
 expect fun rememberFilePicker(
     mimeTypes: List<String>,
+    maxBytes: Long,
+    onFileTooLarge: (name: String) -> Unit,
     onFilePicked: (bytes: ByteArray, name: String) -> Unit,
 ): () -> Unit

--- a/mobile/composeApp/src/commonMain/kotlin/app/indelible/feed/ui/AddFeedScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/app/indelible/feed/ui/AddFeedScreen.kt
@@ -178,6 +178,8 @@ fun AddFeedScreen(
                 val opmlPicker =
                     rememberFilePicker(
                         mimeTypes = listOf("text/xml", "application/xml", "*/*"),
+                        maxBytes = AddFeedViewModel.MAX_OPML_BYTES,
+                        onFileTooLarge = viewModel::onFileTooLarge,
                     ) { bytes, name -> viewModel.importOpml(bytes, name) }
                 OpmlDropZone(
                     isLoading = uiState is AddFeedUiState.OpmlLoading,

--- a/mobile/composeApp/src/commonMain/kotlin/app/indelible/feed/viewmodel/AddFeedViewModel.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/app/indelible/feed/viewmodel/AddFeedViewModel.kt
@@ -6,6 +6,7 @@ import app.indelible.core.i18n.UiMessage
 import app.indelible.feed.model.FeedSubscription
 import app.indelible.feed.repository.FeedRepository
 import indelible.composeapp.generated.resources.Res
+import indelible.composeapp.generated.resources.feed_error_file_too_large
 import indelible.composeapp.generated.resources.feed_error_import_opml
 import indelible.composeapp.generated.resources.feed_error_subscribe
 import indelible.composeapp.generated.resources.feed_opml_import_result
@@ -73,6 +74,12 @@ class AddFeedViewModel(
         fileBytes: ByteArray,
         fileName: String,
     ) {
+        // The picker already rejects oversized files; this keeps any other
+        // caller from sending an absurd payload to the server.
+        if (fileBytes.size > MAX_OPML_BYTES) {
+            onFileTooLarge(fileName)
+            return
+        }
         _uiState.value = AddFeedUiState.OpmlLoading
         viewModelScope.launch {
             repository
@@ -92,5 +99,19 @@ class AddFeedViewModel(
                     _effects.emit(AddFeedEffect.ShowSnackbar(UiMessage(Res.string.feed_error_import_opml)))
                 }
         }
+    }
+
+    fun onFileTooLarge(fileName: String) {
+        val message = UiMessage(Res.string.feed_error_file_too_large, listOf(fileName))
+        _uiState.value = AddFeedUiState.Error(message)
+        viewModelScope.launch { _effects.emit(AddFeedEffect.ShowSnackbar(message)) }
+    }
+
+    companion object {
+        // POST /api/v1/feeds/subscriptions/opml registers no body-limit layer, so
+        // it inherits Axum's 2 MiB default. Capping below that keeps every file we
+        // accept within what the server will take, multipart framing included.
+        // Real OPML exports are tens of kilobytes.
+        const val MAX_OPML_BYTES: Long = 1_048_576L
     }
 }

--- a/mobile/composeApp/src/commonTest/kotlin/app/indelible/feed/viewmodel/AddFeedViewModelTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/app/indelible/feed/viewmodel/AddFeedViewModelTest.kt
@@ -1,0 +1,102 @@
+package app.indelible.feed.viewmodel
+
+import app.indelible.core.i18n.UiMessage
+import indelible.composeapp.generated.resources.Res
+import indelible.composeapp.generated.resources.feed_error_file_too_large
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddFeedViewModelTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var repository: FakeFeedRepository
+    private lateinit var viewModel: AddFeedViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = FakeFeedRepository()
+        viewModel = AddFeedViewModel(repository)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun import_opml_within_cap_reaches_repository() =
+        runTest(testDispatcher) {
+            viewModel.importOpml(ByteArray(1024), "subscriptions.opml")
+            advanceUntilIdle()
+
+            assertEquals(1, repository.importOpmlCallCount)
+            assertEquals("subscriptions.opml", repository.lastImportOpmlFileName)
+            assertIs<AddFeedUiState.Idle>(viewModel.uiState.value)
+        }
+
+    @Test
+    fun import_opml_at_exactly_the_cap_is_accepted() =
+        runTest(testDispatcher) {
+            // The cap is inclusive everywhere it is enforced (picker and here),
+            // so a file of exactly MAX_OPML_BYTES must still import.
+            viewModel.importOpml(ByteArray(AddFeedViewModel.MAX_OPML_BYTES.toInt()), "exact.opml")
+            advanceUntilIdle()
+
+            assertEquals(1, repository.importOpmlCallCount)
+            assertIs<AddFeedUiState.Idle>(viewModel.uiState.value)
+        }
+
+    @Test
+    fun import_opml_over_cap_errors_without_calling_repository() =
+        runTest(testDispatcher) {
+            val oversized = ByteArray((AddFeedViewModel.MAX_OPML_BYTES + 1).toInt())
+
+            val effects = mutableListOf<AddFeedEffect>()
+            val job = launch { viewModel.effects.toList(effects) }
+
+            viewModel.importOpml(oversized, "huge.opml")
+            advanceUntilIdle()
+
+            val state = assertIs<AddFeedUiState.Error>(viewModel.uiState.value)
+            assertEquals(Res.string.feed_error_file_too_large, state.message.resource)
+            assertEquals(listOf("huge.opml"), state.message.formatArgs)
+            assertEquals(0, repository.importOpmlCallCount)
+            assertEquals(
+                UiMessage(Res.string.feed_error_file_too_large, listOf("huge.opml")),
+                effects.filterIsInstance<AddFeedEffect.ShowSnackbar>().single().message,
+            )
+            job.cancel()
+        }
+
+    @Test
+    fun picker_rejection_surfaces_the_too_large_error() =
+        runTest(testDispatcher) {
+            val effects = mutableListOf<AddFeedEffect>()
+            val job = launch { viewModel.effects.toList(effects) }
+
+            viewModel.onFileTooLarge("huge.opml")
+            advanceUntilIdle()
+
+            val state = assertIs<AddFeedUiState.Error>(viewModel.uiState.value)
+            assertEquals(Res.string.feed_error_file_too_large, state.message.resource)
+            assertEquals(0, repository.importOpmlCallCount)
+            assertEquals(
+                UiMessage(Res.string.feed_error_file_too_large, listOf("huge.opml")),
+                effects.filterIsInstance<AddFeedEffect.ShowSnackbar>().single().message,
+            )
+            job.cancel()
+        }
+}

--- a/mobile/composeApp/src/commonTest/kotlin/app/indelible/feed/viewmodel/FakeFeedRepository.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/app/indelible/feed/viewmodel/FakeFeedRepository.kt
@@ -82,10 +82,17 @@ class FakeFeedRepository : FeedRepository {
     var importOpmlResult: Result<OpmlImportResult> =
         Result.success(OpmlImportResult(created = 0, errors = emptyList(), skipped = 0))
 
+    var importOpmlCallCount = 0
+    var lastImportOpmlFileName: String? = null
+
     override suspend fun importOpml(
         fileBytes: ByteArray,
         fileName: String,
-    ): Result<OpmlImportResult> = importOpmlResult
+    ): Result<OpmlImportResult> {
+        importOpmlCallCount++
+        lastImportOpmlFileName = fileName
+        return importOpmlResult
+    }
 
     companion object {
         fun emptyPaginatedFeedItems() =

--- a/mobile/composeApp/src/iosMain/kotlin/app/indelible/core/platform/FilePicker.kt
+++ b/mobile/composeApp/src/iosMain/kotlin/app/indelible/core/platform/FilePicker.kt
@@ -7,6 +7,9 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileSize
+import platform.Foundation.NSNumber
 import platform.Foundation.NSURL
 import platform.Foundation.dataWithContentsOfURL
 import platform.UIKit.UIApplication
@@ -16,13 +19,20 @@ import platform.UniformTypeIdentifiers.UTTypeXML
 import platform.darwin.NSObject
 import platform.posix.memcpy
 
+private const val DEFAULT_FILE_NAME = "import.opml"
+
 @OptIn(ExperimentalForeignApi::class)
 @Composable
 actual fun rememberFilePicker(
     mimeTypes: List<String>,
+    maxBytes: Long,
+    onFileTooLarge: (name: String) -> Unit,
     onFilePicked: (bytes: ByteArray, name: String) -> Unit,
 ): () -> Unit {
-    val delegate = remember(onFilePicked) { DocumentPickerDelegate(onFilePicked) }
+    val delegate =
+        remember(maxBytes, onFileTooLarge, onFilePicked) {
+            DocumentPickerDelegate(maxBytes, onFileTooLarge, onFilePicked)
+        }
     return {
         val picker =
             UIDocumentPickerViewController(
@@ -38,6 +48,8 @@ actual fun rememberFilePicker(
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 private class DocumentPickerDelegate(
+    private val maxBytes: Long,
+    private val onFileTooLarge: (String) -> Unit,
     private val onFilePicked: (ByteArray, String) -> Unit,
 ) : NSObject(),
     UIDocumentPickerDelegateProtocol {
@@ -46,17 +58,35 @@ private class DocumentPickerDelegate(
         didPickDocumentsAtURLs: List<*>,
     ) {
         val url = didPickDocumentsAtURLs.firstOrNull() as? NSURL ?: return
-        val data = NSData.dataWithContentsOfURL(url) ?: return
-        val length = data.length.toInt()
-        val bytes = ByteArray(length)
-        if (length > 0) {
-            bytes.usePinned { pinned ->
-                memcpy(pinned.addressOf(0), data.bytes, data.length)
-            }
+        val name = url.lastPathComponent ?: DEFAULT_FILE_NAME
+        // The picker copies the file into the app's container, so its size is
+        // always readable here; a size we cannot read counts as over the limit
+        // rather than loading a file of unknown length into memory.
+        val size = url.fileSizeOrNull()
+        val withinCap = size != null && size <= maxBytes
+        val data = if (withinCap) NSData.dataWithContentsOfURL(url) else null
+        when {
+            !withinCap -> onFileTooLarge(name)
+            data == null -> Unit
+            data.length.toLong() > maxBytes -> onFileTooLarge(name)
+            else -> onFilePicked(data.toByteArray(), name)
         }
-        val name = url.lastPathComponent ?: "import.opml"
-        onFilePicked(bytes, name)
     }
 
     override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {}
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSURL.fileSizeOrNull(): Long? {
+    val attributes = path?.let { NSFileManager.defaultManager.attributesOfItemAtPath(it, null) }
+    return (attributes?.get(NSFileSize) as? NSNumber)?.longLongValue
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val copy = ByteArray(length.toInt())
+    if (copy.isNotEmpty()) {
+        copy.usePinned { pinned -> memcpy(pinned.addressOf(0), bytes, length) }
+    }
+    return copy
 }

--- a/mobile/composeApp/src/jvmMain/kotlin/app/indelible/core/platform/FilePicker.kt
+++ b/mobile/composeApp/src/jvmMain/kotlin/app/indelible/core/platform/FilePicker.kt
@@ -2,8 +2,12 @@ package app.indelible.core.platform
 
 import androidx.compose.runtime.Composable
 
+// Desktop has no file picker yet; the size cap lives with the implementation,
+// so a future actual must check File.length() against maxBytes before reading.
 @Composable
 actual fun rememberFilePicker(
     mimeTypes: List<String>,
+    maxBytes: Long,
+    onFileTooLarge: (name: String) -> Unit,
     onFilePicked: (bytes: ByteArray, name: String) -> Unit,
 ): () -> Unit = {}


### PR DESCRIPTION
- `rememberFilePicker` read picked files fully into memory with no cap; a huge pick OOM-crashed Android
- all platform actuals now check size before reading; unknown-size falls back to a bounded read (never more than maxBytes+1 bytes in memory)
- 1 MiB client cap for OPML (`MAX_OPML_BYTES`) — the server route inherits axum's 2 MiB body default, so the cap leaves framing headroom
- defense-in-depth guard in `AddFeedViewModel.importOpml`; localized error (en+fr); boundary + snackbar + no-repository-call tests