### PR TITLE
docs: document upload size limits in env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ S3_BUCKET=indelible
 S3_REGION=us-east-1
 S3_FORCE_PATH_STYLE=true
 
+# Largest single file accepted by a library upload, in bytes (default 50 MiB).
+#UPLOAD_MAX_BYTES=52428800
+# Maximum total size of a Readwise import bundle, including its optional OPML file, in bytes (default 200 MiB).
+#IMPORT_UPLOAD_MAX_BYTES=209715200
+
 # Signups close automatically once the first account exists, so a fresh
 # instance still gets its owner with nothing to switch off afterwards.
 # Set this to true only while you are letting additional people register.

--- a/website/public/quickstart/env.example
+++ b/website/public/quickstart/env.example
@@ -25,3 +25,8 @@
 # Exact browser Identity callbacks accepted by the extension PKCE flow.
 # Include every Chrome, Edge, and Firefox build you distribute.
 #EXTENSION_REDIRECT_URIS=https://lblngpkieoichinegfhgacmcjbahjbek.chromiumapp.org/indelible,https://<edge-id>.chromiumapp.org/indelible,https://38bd18db5de5caccb6ab6c1271fec03ec1662d5c.extensions.allizom.org/indelible
+
+# Largest single file accepted by a library upload, in bytes (default 50 MiB).
+#UPLOAD_MAX_BYTES=52428800
+# Maximum total size of a Readwise import bundle, including its optional OPML file, in bytes (default 200 MiB).
+#IMPORT_UPLOAD_MAX_BYTES=209715200

--- a/website/src/content/docs/docs/reference/configuration.md
+++ b/website/src/content/docs/docs/reference/configuration.md
@@ -24,7 +24,7 @@ and `ind-worker` unless noted.
 | `S3_ENABLED` | no | Turns on object storage. Defaults to `false`, but is enabled automatically when `S3_ENDPOINT` is set. Archived content and uploads require object storage |
 | `S3_ENDPOINT` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_BUCKET` / `S3_REGION` / `S3_FORCE_PATH_STYLE` | yes | S3-compatible object storage for archived content. Set on `ind-api`, `ind-worker`, and `ind-renderer` |
 | `UPLOAD_MAX_BYTES` | no | Maximum upload size for files saved to the library |
-| `IMPORT_UPLOAD_MAX_BYTES` | no | Maximum upload size for Readwise/OPML imports (default 200 MiB) |
+| `IMPORT_UPLOAD_MAX_BYTES` | no | Maximum total size of a Readwise import bundle, including optional OPML (default 200 MiB) |
 
 ## Object storage
 


### PR DESCRIPTION
- `UPLOAD_MAX_BYTES` (default 50 MiB) and `IMPORT_UPLOAD_MAX_BYTES` (default 200 MiB) were real override knobs documented nowhere in the env examples
- added commented-out entries with defaults to `.env.example` and the published quickstart `env.example`