### PR TITLE
chore(extension): update defuddle to 0.19.3

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "defuddle": "^0.18.1",
+        "defuddle": "^0.19.3",
         "single-file-core": "^1.3.51"
       },
       "devDependencies": {
@@ -3396,9 +3396,9 @@
       "license": "MIT"
     },
     "node_modules/defuddle": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/defuddle/-/defuddle-0.18.1.tgz",
-      "integrity": "sha512-AvFPFOsoDjt5xUOA1QxzafSSzJ5dqEIC63yO72tHYtSjj1DYY/XM0XTPUCsHkm5A2f1X9ulBvoSVFJrd4s2ckA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/defuddle/-/defuddle-0.19.3.tgz",
+      "integrity": "sha512-5ZbOQ/B+iiRRqSQWwmCx/zEuqZOA/5q7gxyE2/4O2Bxq7nUC0PgKw9EdyxqWbFF1nrrrYemSeR25jg4TmA2fsA==",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0"
@@ -3408,8 +3408,8 @@
       },
       "optionalDependencies": {
         "linkedom": "^0.18.12",
-        "mathml-to-latex": "^1.5.0",
-        "temml": "^0.13.1",
+        "mathml-to-latex": "^1.8.0",
+        "temml": "^0.13.3",
         "turndown": "^7.2.0"
       }
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -27,7 +27,7 @@
     "postinstall": "wxt prepare && node scripts/copy-singlefile.js"
   },
   "dependencies": {
-    "defuddle": "^0.18.1",
+    "defuddle": "^0.19.3",
     "single-file-core": "^1.3.51"
   },
   "devDependencies": {


### PR DESCRIPTION
- 0.19.2 fixes Wikipedia content truncation; 0.19.3 fixes unsafe schema.org HTML handling and SVG SMIL injection
- the extension runs defuddle over arbitrary pages, so the parser hardening matters
- supersedes #11