### PR TITLE
fix: anchor docs ignore rule to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ ARCHITECTURE.md
 /.playwright-mcp
 /.history
 /.nodeterm
-docs/
+/docs/


### PR DESCRIPTION
- `docs/` unanchored matches every directory named `docs` at any depth, including `website/src/content/docs/` — new documentation pages were silently skipped by `git add`
- anchoring to `/docs/` keeps the intended repo-root scratch directory ignored while making the website docs tree addable again
- one already-written page (`website/src/content/docs/docs/how-to/translate-indelible.md`) was being hidden by this rule and can now be committed