### PR TITLE
fix(html): keep reader classes and YouTube embeds through sanitization

### DIFF
--- a/backend/crates/ind-html/src/lib.rs
+++ b/backend/crates/ind-html/src/lib.rs
@@ -1,4 +1,5 @@
 mod prepare;
+mod reader_allowlist;
 mod toc;
 
 pub use prepare::{ANCHOR_ID_PREFIX, PrepareError, prepare_reader_html};
@@ -58,14 +59,18 @@ fn html_body_fragment(html: &str) -> String {
         .unwrap_or_else(|| html.to_string())
 }
 
-/// Sanitize untrusted HTML for safe rendering in the reader. Uses ammonia's
-/// vetted default allowlist, which strips `<script>`/`<style>`/`<iframe>`,
-/// inline event handlers, and dangerous URL schemes while preserving article
-/// formatting. Content write paths call `prepare_reader_html` (which sanitizes
-/// AND makes anchors durable); this remains the documented fallback when
-/// preparation fails, so a rewriter error can never fail ingest.
+/// Keeps `class`, `span[data-t]`, and YouTube-embed iframes; drops every other iframe.
+/// Infallible: fallback for `prepare_reader_html` on the content write paths.
 pub fn sanitize_reader_html(html: &str) -> String {
-    ammonia::clean(html)
+    match reader_allowlist::drop_foreign_iframes(html) {
+        Ok(filtered) => reader_allowlist::reader_sanitizer()
+            .clean(&filtered)
+            .to_string(),
+        Err(_) => reader_allowlist::reader_sanitizer()
+            .rm_tags(&["iframe"])
+            .clean(html)
+            .to_string(),
+    }
 }
 
 fn is_non_content_html_element(element: &ElementRef<'_>) -> bool {

--- a/backend/crates/ind-html/src/prepare.rs
+++ b/backend/crates/ind-html/src/prepare.rs
@@ -1,17 +1,5 @@
-//! Reader-HTML preparation: sanitize untrusted article HTML and make its anchors
-//! durable, so a stored document supports table-of-contents navigation and working
-//! in-document links on every client.
-//!
-//! Every retained `id` gets the `ind-` prefix and every local fragment href is
-//! rewritten to match, because a fragment link is only as good as its target.
-//! Headings without ids get slugified `ind-toc-*` ids; footnote list items and
-//! citation anchors get ids inferred from the `#fn:`/`#fnref:` link graph that
-//! readability extractors emit (legacy stored content lost the original targets
-//! to sanitization, leaving every footnote link dead).
-//!
-//! The output is byte-for-byte idempotent: anything already prefixed is never
-//! touched again, which is what lets re-preparation double as a cheap
-//! "is this content already prepared" check.
+//! Sanitizes reader HTML and gives headings, footnotes, and citations durable `ind-` ids.
+//! Output is byte-for-byte idempotent.
 
 use std::cell::Cell;
 use std::collections::HashSet;
@@ -31,44 +19,31 @@ pub enum PrepareError {
     Rewrite(String),
 }
 
-/// Sanitize untrusted article HTML and inject durable anchors. Replaces
-/// `sanitize_reader_html` at content write paths; callers fall back to plain
-/// sanitization on error rather than failing ingest.
+/// On error callers fall back to `sanitize_reader_html`; ingest never fails on this.
 pub fn prepare_reader_html(html: &str) -> Result<String, PrepareError> {
-    let sanitized = sanitize_keeping_ids(html);
+    let filtered = crate::reader_allowlist::drop_foreign_iframes(html)
+        .map_err(|err| PrepareError::Rewrite(err.to_string()))?;
+    let sanitized = sanitize_keeping_ids(&filtered);
     let plan = build_rewrite_plan(&sanitized);
     let rewritten = apply(&plan, &sanitized)?;
-    // Ammonia serializes attributes in canonical order while lol_html appends
-    // injected ones at the tag end; a final sanitize pass canonicalizes the
-    // output so preparation is byte-for-byte idempotent.
+    // The final pass canonicalizes attribute order so the output is byte-for-byte idempotent.
     Ok(sanitize_keeping_ids(&rewritten))
 }
 
-/// Ammonia's vetted default allowlist, plus `id` — the defaults strip it, which is
-/// exactly what orphaned every fragment link in previously stored content. Ids are
-/// safe to retain because the apply pass namespaces every one of them with
-/// [`ANCHOR_ID_PREFIX`], which also prevents DOM clobbering of host-page globals.
+/// Retained ids are safe only because `apply` prefixes every one with [`ANCHOR_ID_PREFIX`].
 fn sanitize_keeping_ids(html: &str) -> String {
-    ammonia::Builder::default()
+    crate::reader_allowlist::reader_sanitizer()
         .add_generic_attributes(&["id"])
         .clean(html)
         .to_string()
 }
 
-/// Ids to inject, addressed by element ordinal so the streaming apply pass can
-/// assign them without re-parsing. Ordinals count, per element type, exactly the
-/// elements the apply pass's selectors visit.
+/// Indexed by element ordinal per selector (`h1..h6`, `li`, `a[href]`) in document order.
 struct RewritePlan {
-    /// By `h1..h6` ordinal; `Some` only for headings that need an injected id.
     heading_ids: Vec<Option<String>>,
-    /// By `li` ordinal; `Some` for footnote items identified via their backlinks.
     li_ids: Vec<Option<String>>,
-    /// By `a[href]` ordinal; `Some` for citation anchors that footnote backlinks
-    /// point back at.
     anchor_ids: Vec<Option<String>>,
-    /// By `a[href]` ordinal; `true` when the link's local fragment has no target
-    /// anywhere in the final document (extraction removed it). The href is
-    /// stripped so the link degrades to inert text instead of a broken jump.
+    /// `true` strips the href: its local fragment has no target in the final document.
     dead_anchors: Vec<bool>,
 }
 
@@ -80,8 +55,7 @@ fn build_rewrite_plan(sanitized: &str) -> RewritePlan {
         .filter_map(ElementRef::wrap)
         .collect();
 
-    // The collision namespace is the FINAL id set: existing ids as they will look
-    // after prefixing, plus everything assigned below.
+    // Collision namespace is the final id set: prefixed existing ids plus everything assigned below.
     let mut used: HashSet<String> = elements
         .iter()
         .filter_map(|el| el.value().attr("id"))
@@ -123,8 +97,6 @@ fn build_rewrite_plan(sanitized: &str) -> RewritePlan {
         heading_ids.push(Some(claim_unique(base, &mut used)));
     }
 
-    // `used` now holds the complete final id namespace; any local fragment
-    // without a member there can never resolve.
     let dead_anchors = anchors
         .iter()
         .map(|a| {
@@ -145,9 +117,7 @@ fn build_rewrite_plan(sanitized: &str) -> RewritePlan {
     }
 }
 
-/// A footnote item is recognized by the backlink(s) it contains: readability
-/// output puts `<a href="#fnref:N">` (or `#fnref:N-k` for repeat citations)
-/// inside `<li>` N of the footnote list, so the base name identifies the item.
+/// Footnote `<li>` N is identified by its `#fnref:N` (or `#fnref:N-k`) backlink.
 fn footnote_li_id(li: &ElementRef<'_>, used: &mut HashSet<String>) -> Option<String> {
     if li.value().attr("id").is_some() {
         return None;
@@ -166,10 +136,7 @@ fn footnote_li_id(li: &ElementRef<'_>, used: &mut HashSet<String>) -> Option<Str
     Some(id)
 }
 
-/// Citation anchors (`<a href="#fn:N">`) receive the ids the footnote backlinks
-/// already reference: the first citation of footnote N is `fnref:N`, the k-th is
-/// `fnref:N-k` — the convention readability extractors use when generating the
-/// backlinks, so the two sides meet.
+/// The k-th citation of footnote N gets `fnref:N-k` (`fnref:N` for k = 1), matching its backlink.
 fn citation_anchor_id(
     a: &ElementRef<'_>,
     citation_counts: &mut Vec<(String, usize)>,
@@ -207,8 +174,6 @@ fn apply(plan: &RewritePlan, html: &str) -> Result<String, PrepareError> {
     let anchor_i = Cell::new(0usize);
 
     let settings = RewriteStrSettings::new()
-        // Prefix every retained id, whatever the element: fragment hrefs are
-        // rewritten globally below, so their targets must move with them.
         .append_element_content_handler(element!("[id]", |el: &mut Element| {
             if let Some(id) = el.get_attribute("id")
                 && !id.starts_with(ANCHOR_ID_PREFIX)
@@ -270,9 +235,7 @@ fn is_heading(name: &str) -> bool {
     matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
 }
 
-/// `#fnref:1-2` names occurrence 2 of footnote 1; the base identifies the footnote.
-/// The suffix is stripped only when purely numeric so footnotes whose own names
-/// contain dashes are left intact.
+/// `fnref:1-2` → `fnref:1`; a non-numeric suffix is part of the footnote name and kept.
 fn occurrence_base(name: &str) -> &str {
     match name.rfind('-') {
         Some(pos)
@@ -286,8 +249,7 @@ fn occurrence_base(name: &str) -> &str {
     }
 }
 
-/// The name of a `#`-fragment href after `marker`, accepting both raw and
-/// already-prefixed forms so re-preparation sees the same graph.
+/// Accepts both raw and `ind-`-prefixed fragments so re-preparation sees the same graph.
 fn fragment_name(href: &str, marker: &str) -> Option<String> {
     let fragment = href.strip_prefix('#')?;
     let fragment = fragment.strip_prefix(ANCHOR_ID_PREFIX).unwrap_or(fragment);

--- a/backend/crates/ind-html/src/reader_allowlist.rs
+++ b/backend/crates/ind-html/src/reader_allowlist.rs
@@ -1,0 +1,47 @@
+//! Sanitizer allowlist shared by every reader-HTML write path.
+
+use lol_html::errors::RewritingError;
+use lol_html::{RewriteStrSettings, element, rewrite_str};
+
+pub(crate) const YOUTUBE_EMBED_PREFIXES: [&str; 2] = [
+    "https://www.youtube.com/embed/",
+    "https://www.youtube-nocookie.com/embed/",
+];
+
+/// Never combine with `allowed_classes`: ammonia panics at `clean()` when both are set.
+pub(crate) fn reader_sanitizer() -> ammonia::Builder<'static> {
+    let mut builder = ammonia::Builder::default();
+    builder
+        .add_tags(&["iframe"])
+        .add_tag_attributes(
+            "iframe",
+            &[
+                "src",
+                "width",
+                "height",
+                "frameborder",
+                "allowfullscreen",
+                "allow",
+            ],
+        )
+        .add_generic_attributes(&["class"])
+        .add_tag_attributes("span", &["data-t"]);
+    builder
+}
+
+/// Must run before `reader_sanitizer`, which allows `iframe` without checking `src`.
+pub(crate) fn drop_foreign_iframes(html: &str) -> Result<String, RewritingError> {
+    let settings =
+        RewriteStrSettings::new().append_element_content_handler(element!("iframe", |el| {
+            let allowed = el.get_attribute("src").is_some_and(|src| {
+                YOUTUBE_EMBED_PREFIXES
+                    .iter()
+                    .any(|prefix| src.starts_with(prefix))
+            });
+            if !allowed {
+                el.remove();
+            }
+            Ok(())
+        }));
+    rewrite_str(html, settings)
+}

--- a/backend/crates/ind-html/tests/sanitize_tests.rs
+++ b/backend/crates/ind-html/tests/sanitize_tests.rs
@@ -1,0 +1,37 @@
+#![allow(clippy::unwrap_used)]
+
+const YT: &str = r#"<div class="yt-embed"><iframe width="560" height="315" src="https://www.youtube.com/embed/abc123" frameborder="0" allowfullscreen></iframe></div><section class="yt-transcript"><p><span class="t-seg" data-t="0:12">Hello</span></p></section>"#;
+
+#[test]
+fn reader_sanitizer_keeps_youtube_embed_and_reader_classes() {
+    let out = ind_html::sanitize_reader_html(YT);
+    assert!(
+        out.contains(r#"src="https://www.youtube.com/embed/abc123""#),
+        "{out}"
+    );
+    assert!(out.contains(r#"class="yt-embed""#), "{out}");
+    assert!(out.contains(r#"data-t="0:12""#), "{out}");
+}
+
+#[test]
+fn reader_sanitizer_drops_non_youtube_iframes() {
+    let out = ind_html::sanitize_reader_html(
+        r#"<p>a</p><iframe src="https://evil.example/x"></iframe><iframe src="javascript:alert(1)"></iframe><iframe></iframe>"#,
+    );
+    assert!(!out.contains("iframe"), "{out}");
+}
+
+#[test]
+fn reader_sanitizer_still_strips_scripts_and_handlers() {
+    let out = ind_html::sanitize_reader_html(r#"<p onclick="x()">a</p><script>1</script>"#);
+    assert_eq!(out, "<p>a</p>");
+}
+
+#[test]
+fn prepare_is_idempotent_on_youtube_html() {
+    let once = ind_html::prepare_reader_html(YT).unwrap();
+    let twice = ind_html::prepare_reader_html(&once).unwrap();
+    assert_eq!(once, twice);
+    assert!(once.contains("youtube.com/embed/abc123"));
+    assert!(once.contains(r#"class="t-seg""#));
+}


### PR DESCRIPTION
- reader sanitizer allows iframe (YouTube embed prefixes only, enforced by a lol_html pre-pass), class, and span[data-t]
- prepare_reader_html and sanitize_reader_html share the allowlist so the ToC pass no longer strips the video frame
- existing videos regain the frame after Retry processing; no backfill