### PR TITLE
feat(api): accept text-quote context on highlights

### DIFF
--- a/backend/apps/ind-api/tests/api.rs
+++ b/backend/apps/ind-api/tests/api.rs
@@ -22,6 +22,7 @@ mod api {
     mod extension_auth_journey_tests;
     mod feed_route_permission_tests;
     mod feed_subscription_journey_tests;
+    mod highlight_text_quote_tests;
     mod integration_availability_tests;
     mod integration_journey_tests;
     mod integration_route_permission_tests;

--- a/backend/apps/ind-api/tests/api/highlight_text_quote_tests.rs
+++ b/backend/apps/ind-api/tests/api/highlight_text_quote_tests.rs
@@ -1,0 +1,72 @@
+use ind_application::repos::document_asset::DocumentAssetRepository;
+use ind_domain::{ArchiveAssetKind, ArchiveAssetStatus, DocumentType, NewDocumentAsset};
+use ind_persistence::repos::PgDocumentAssetRepository;
+use ind_test_support::{DocumentFactory, spawn_app};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use super::common::{assert_json_response, assert_status};
+
+#[tokio::test]
+async fn text_quote_context_round_trips_through_create_and_list() {
+    let app = spawn_app().await;
+    let owner = app.create_web_session().await;
+    let client = app.authed_client(&owner);
+    let document = DocumentFactory::new(owner.user.id)
+        .with_document_type(DocumentType::Article)
+        .insert(app.pool())
+        .await;
+    PgDocumentAssetRepository::new(app.pool().clone())
+        .upsert_document_asset(NewDocumentAsset {
+            document_id: document.id,
+            asset_kind: ArchiveAssetKind::ReadableHtml,
+            s3_key: format!("tests/text-quote/{}", document.id),
+            s3_bucket: "test-bucket".into(),
+            content_type: "text/html".into(),
+            size_bytes: 64,
+            status: ArchiveAssetStatus::Completed,
+            failed_reason: None,
+        })
+        .await
+        .unwrap();
+    let path = format!("/api/v1/documents/{}/highlights", document.id);
+
+    let created = assert_json_response(
+        client
+            .post_json(
+                &path,
+                &json!({
+                    "color": "yellow",
+                    "text_content": "Beta target",
+                    "locator": { "type": "html", "start_offset": 14, "end_offset": 25 },
+                    "source_locator": { "type": "text_quote", "prefix": "phrase. ", "suffix": "." }
+                }),
+            )
+            .await,
+        StatusCode::CREATED,
+    )
+    .await;
+    assert_eq!(created["source_locator"]["type"], "text_quote");
+
+    let listed = assert_json_response(client.get(&path).await, StatusCode::OK).await;
+    let stored = &listed["highlights"][0]["source_locator"];
+    assert_eq!(stored["type"], "text_quote");
+    assert_eq!(stored["prefix"], "phrase. ");
+    assert_eq!(stored["suffix"], ".");
+
+    assert_status(
+        client
+            .post_json(
+                &path,
+                &json!({
+                    "color": "yellow",
+                    "text_content": "Beta target",
+                    "locator": { "type": "html", "start_offset": 14, "end_offset": 25 },
+                    "source_locator": { "type": "text_quote" }
+                }),
+            )
+            .await,
+        StatusCode::UNPROCESSABLE_ENTITY,
+    )
+    .await;
+}

--- a/backend/crates/ind-application/src/handlers/highlight/tests.rs
+++ b/backend/crates/ind-application/src/handlers/highlight/tests.rs
@@ -136,3 +136,28 @@ fn pdf_rectangles_and_source_ranges_reject_each_invalid_dimension() {
         );
     }
 }
+
+#[test]
+fn text_quote_source_locator_needs_prefix_or_suffix() {
+    let empty = HighlightSourceLocator::TextQuote {
+        prefix: Some(" ".into()),
+        suffix: None,
+    };
+    assert_eq!(
+        field(validate_highlight_locators_for_document(
+            DocumentType::Article,
+            None,
+            Some(&empty),
+        )),
+        "source_locator.prefix"
+    );
+
+    let with_suffix = HighlightSourceLocator::TextQuote {
+        prefix: None,
+        suffix: Some(".".into()),
+    };
+    assert!(
+        validate_highlight_locators_for_document(DocumentType::Article, None, Some(&with_suffix))
+            .is_ok()
+    );
+}

--- a/backend/crates/ind-application/src/handlers/highlight/validation.rs
+++ b/backend/crates/ind-application/src/handlers/highlight/validation.rs
@@ -129,6 +129,18 @@ fn validate_source_locator(locator: &HighlightSourceLocator) -> Result<(), AppEr
             }
             Ok(())
         }
+        HighlightSourceLocator::TextQuote { prefix, suffix } => {
+            let has_context = [prefix, suffix]
+                .iter()
+                .any(|value| value.as_deref().is_some_and(|s| !s.trim().is_empty()));
+            if !has_context {
+                return Err(AppError::Domain(DomainError::Validation {
+                    field: "source_locator.prefix".into(),
+                    message: "text_quote needs a non-empty prefix or suffix".into(),
+                }));
+            }
+            Ok(())
+        }
     }
 }
 

--- a/backend/crates/ind-domain/src/highlight.rs
+++ b/backend/crates/ind-domain/src/highlight.rs
@@ -73,6 +73,12 @@ pub enum HighlightSourceLocator {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         suffix: Option<String>,
     },
+    TextQuote {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prefix: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suffix: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/crates/ind-http-api/src/routes/highlights/dto.rs
+++ b/backend/crates/ind-http-api/src/routes/highlights/dto.rs
@@ -38,7 +38,7 @@ pub struct LocatorSchemaFlat {
 
 #[derive(Serialize, ToSchema)]
 pub struct SourceLocatorSchemaFlat {
-    /// Discriminator: "web_page_dom_range"
+    /// Discriminator: "web_page_dom_range" or "text_quote"
     #[serde(rename = "type")]
     pub locator_type: String,
     pub url: Option<String>,
@@ -192,6 +192,12 @@ pub enum SourceLocatorSchema {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         suffix: Option<String>,
     },
+    TextQuote {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prefix: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        suffix: Option<String>,
+    },
 }
 
 impl From<SourceLocatorSchema> for ind_domain::HighlightSourceLocator {
@@ -212,6 +218,7 @@ impl From<SourceLocatorSchema> for ind_domain::HighlightSourceLocator {
                 prefix,
                 suffix,
             },
+            SourceLocatorSchema::TextQuote { prefix, suffix } => Self::TextQuote { prefix, suffix },
         }
     }
 }
@@ -234,6 +241,9 @@ impl From<ind_domain::HighlightSourceLocator> for SourceLocatorSchema {
                 prefix,
                 suffix,
             },
+            ind_domain::HighlightSourceLocator::TextQuote { prefix, suffix } => {
+                Self::TextQuote { prefix, suffix }
+            }
         }
     }
 }


### PR DESCRIPTION
- source_locator gains a text_quote variant (prefix/suffix) on the existing jsonb column
- validation requires a non-empty prefix or suffix
- flat OpenAPI schema unchanged