### PR TITLE
feat(shared): add citation-tolerant text anchoring

### DIFF
--- a/extension/tests/highlight-projection.test.ts
+++ b/extension/tests/highlight-projection.test.ts
@@ -37,7 +37,7 @@ describe('highlight projection', () => {
   })
 
   it('uses source offset to choose between repeated text matches', () => {
-    document.body.innerHTML = '<p>Alpha target.</p><p>Beta target.</p>'
+    document.body.innerHTML = `<p>Alpha target.</p><p>${'filler text. '.repeat(10)}</p><p>Beta target.</p>`
     const secondTargetOffset = document.body.textContent?.lastIndexOf('target') ?? 0
 
     const highlight: ProjectedHighlight = {
@@ -56,7 +56,7 @@ describe('highlight projection', () => {
 
     const paragraphs = Array.from(document.querySelectorAll('p'))
     expect(paragraphs[0]?.querySelector('mark')).toBeNull()
-    expect(paragraphs[1]?.querySelector('mark')?.textContent).toBe('target')
+    expect(paragraphs[2]?.querySelector('mark')?.textContent).toBe('target')
   })
 
   it('falls back from a stale source locator and matches normalized repeated text context', () => {

--- a/extension/tests/highlight-source.test.ts
+++ b/extension/tests/highlight-source.test.ts
@@ -43,6 +43,14 @@ describe('normalizeForMatch', () => {
     expect(normalizeForMatch('Call 911. Then').text).toBe('Call 911. Then')
   })
 
+  it('drops chained citations and interlanguage markers', () => {
+    expect(normalizeForMatch('(IMEC).43 44 Louis-Jean').text).toBe('(IMEC). Louis-Jean')
+    expect(normalizeForMatch('(IMEC).[43][44] Louis-Jean').text).toBe('(IMEC). Louis-Jean')
+    expect(normalizeForMatch('Paul Chavigny [fr]. Sertillanges').text).toBe(
+      'Paul Chavigny. Sertillanges',
+    )
+  })
+
   it('removes a space before an apostrophe and folds quotes and dashes', () => {
     expect(normalizeForMatch("Sertillanges ' book").text).toBe("Sertillanges' book")
     expect(normalizeForMatch('“Card file” – it’s').text).toBe(`"Card file" - it's`)
@@ -91,6 +99,22 @@ describe('findBestTextMatch / resolveTextAnchor', () => {
     expect(resolveTextAnchor('Alpha target. Beta target.', { text: 'target' })).toEqual({
       kind: 'ambiguous',
     })
+  })
+
+  it('anchors a long quote by its ends when the middle drifted', () => {
+    const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor '
+    const page =
+      'Intro. ' +
+      filler.repeat(3) +
+      'middle with [fr] marker and a caption ' +
+      filler.repeat(3) +
+      'the end of it. Outro.'
+    const quote = filler.repeat(3) + 'middle with marker ' + filler.repeat(3) + 'the end of it.'
+    const r = resolveTextAnchor(page, { text: quote })
+    expect(r).toMatchObject({ kind: 'placed', via: 'ends' })
+    if (r.kind !== 'placed') return
+    expect(page.slice(r.start, r.end).startsWith('lorem ipsum')).toBe(true)
+    expect(page.slice(r.start, r.end).endsWith('the end of it.')).toBe(true)
   })
 
   it('accepts a hint whose text still matches, falls back when it does not', () => {

--- a/extension/tests/highlight-source.test.ts
+++ b/extension/tests/highlight-source.test.ts
@@ -51,6 +51,14 @@ describe('normalizeForMatch', () => {
     )
   })
 
+  it('treats a citation cut by the selection edge as a citation', () => {
+    expect(normalizeForMatch('invention of wikis.[5').text).toBe('invention of wikis.')
+    expect(normalizeForMatch('5] In the 1990s').text).toBe('In the 1990s')
+    expect(
+      findBestTextMatch('the invention of wikis.5 Use in', 'invention of wikis.[5'),
+    ).toBeDefined()
+  })
+
   it('removes a space before an apostrophe and folds quotes and dashes', () => {
     expect(normalizeForMatch("Sertillanges ' book").text).toBe("Sertillanges' book")
     expect(normalizeForMatch('“Card file” – it’s').text).toBe(`"Card file" - it's`)

--- a/extension/tests/highlight-source.test.ts
+++ b/extension/tests/highlight-source.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findBestTextMatch,
+  normalizeForMatch,
+  resolveTextAnchor,
+} from '../../shared/highlight-source'
+
+describe('normalizeForMatch', () => {
+  it('collapses whitespace and keeps span maps', () => {
+    const r = normalizeForMatch('a  b\n\nc')
+    expect(r.text).toBe('a b c')
+    expect(r.starts).toEqual([0, 1, 3, 4, 6])
+    expect(r.ends).toEqual([1, 3, 4, 6, 7])
+  })
+
+  it('drops bracketed citations and attributes them to the preceding character', () => {
+    const r = normalizeForMatch('form.[35] French')
+    expect(r.text).toBe('form. French')
+    expect(r.ends[4]).toBe('form.[35]'.length)
+  })
+
+  it('drops bare renumbered citations glued to sentence punctuation', () => {
+    const r = normalizeForMatch('drawers.39 The notes')
+    expect(r.text).toBe('drawers. The notes')
+    expect(r.ends[7]).toBe('drawers.39'.length)
+  })
+
+  it('drops a mid-sentence bare citation the same way as a bracketed one', () => {
+    expect(normalizeForMatch('final form.39 french theorist').text).toBe(
+      'final form. french theorist',
+    )
+    expect(normalizeForMatch('final form.[35] french theorist').text).toBe(
+      'final form. french theorist',
+    )
+  })
+
+  it('keeps decimals, versions, section numbers and unglued numbers', () => {
+    expect(normalizeForMatch('version 3.14 released').text).toBe('version 3.14 released')
+    expect(normalizeForMatch('Section 2.3 covers').text).toBe('Section 2.3 covers')
+    expect(normalizeForMatch('pp. 12 and').text).toBe('pp. 12 and')
+    expect(normalizeForMatch('in 1980.').text).toBe('in 1980.')
+    expect(normalizeForMatch('Call 911. Then').text).toBe('Call 911. Then')
+  })
+
+  it('removes a space before an apostrophe and folds quotes and dashes', () => {
+    expect(normalizeForMatch("Sertillanges ' book").text).toBe("Sertillanges' book")
+    expect(normalizeForMatch('“Card file” – it’s').text).toBe(`"Card file" - it's`)
+  })
+})
+
+describe('findBestTextMatch / resolveTextAnchor', () => {
+  const page = 'Intro. Paxson filed notes daily.[34] The notes were ordered. End.'
+
+  it('matches reader text with a renumbered bare citation and covers the page citation', () => {
+    const m = findBestTextMatch(page, 'Paxson filed notes daily.39 The notes were ordered.')!
+    expect(page.slice(m.start, m.end)).toBe('Paxson filed notes daily.[34] The notes were ordered.')
+  })
+
+  it('matches across an inserted space before an apostrophe', () => {
+    const src = "Antonin Sertillanges ' book The Life"
+    const m = findBestTextMatch(src, "Sertillanges' book")!
+    expect(src.slice(m.start, m.end)).toBe("Sertillanges ' book")
+  })
+
+  it('uses context to pick among repeats', () => {
+    const src = 'Alpha target. Beta target.'
+    expect(findBestTextMatch(src, 'target', { prefix: 'Beta', suffix: '.' })!.start).toBe(
+      src.lastIndexOf('target'),
+    )
+  })
+
+  it('context outranks a badly drifted offset', () => {
+    const src = 'Alpha target. ' + 'filler text. '.repeat(200) + 'Beta target.'
+    const m = findBestTextMatch(src, 'target', { offset: 6, prefix: 'Beta', suffix: '.' })!
+    expect(m.start).toBe(src.lastIndexOf('target'))
+  })
+
+  it('uses the nearest offset only when the runner-up is clearly farther', () => {
+    const far = 'Alpha target. ' + 'filler text. '.repeat(10) + 'Beta target.'
+    expect(findBestTextMatch(far, 'target', { offset: far.lastIndexOf('target') - 5 })!.start).toBe(
+      far.lastIndexOf('target'),
+    )
+    expect(
+      findBestTextMatch('Alpha target. Beta target.', 'target', { offset: 20 }),
+    ).toBeUndefined()
+  })
+
+  it('refuses to guess between unhinted repeats', () => {
+    expect(findBestTextMatch('Alpha target. Beta target.', 'target')).toBeUndefined()
+    expect(resolveTextAnchor('Alpha target. Beta target.', { text: 'target' })).toEqual({
+      kind: 'ambiguous',
+    })
+  })
+
+  it('accepts a hint whose text still matches, falls back when it does not', () => {
+    const src = 'Alpha target. Beta target.'
+    expect(
+      resolveTextAnchor(src, { text: 'Beta target', hint: { start: 14, end: 25 } }),
+    ).toMatchObject({ kind: 'placed', via: 'hint' })
+    expect(
+      resolveTextAnchor(src, { text: 'Beta target', hint: { start: 0, end: 11 } }),
+    ).toMatchObject({ kind: 'placed', via: 'search', start: 14 })
+    expect(resolveTextAnchor(src, { text: 'absent' })).toEqual({ kind: 'missing' })
+  })
+})

--- a/extension/tests/highlight-source.test.ts
+++ b/extension/tests/highlight-source.test.ts
@@ -94,6 +94,45 @@ describe('findBestTextMatch / resolveTextAnchor', () => {
     ).toBeUndefined()
   })
 
+  it('does not equate real numbers that only look like citations', () => {
+    expect(findBestTextMatch('Temperature:43 degrees', 'Temperature:42 degrees')).toBeUndefined()
+    expect(findBestTextMatch('See Fig.3 Details', 'See Fig.2 Details')).toBeUndefined()
+    expect(
+      resolveTextAnchor('Temperature:43 degrees', {
+        text: 'Temperature:42 degrees',
+        hint: { start: 0, end: 22 },
+      }),
+    ).toEqual({ kind: 'missing' })
+    expect(findBestTextMatch('final form.[35] French', 'final form.40 French')).toBeDefined()
+    expect(findBestTextMatch('(IMEC).[43][44] Louis', '(IMEC).43 44 Louis')).toBeDefined()
+  })
+
+  it('covers a leading citation in the matched span', () => {
+    const m = findBestTextMatch('x [35] Intro y', '[40] Intro')!
+    expect('x [35] Intro y'.slice(m.start, m.end)).toBe('[35] Intro')
+  })
+
+  it('uses offset and suffix hints to pick the right long passage by its ends', () => {
+    const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor '
+    const passage = filler + 'a caption (image) sits here ' + filler + 'the end of it.'
+    const page = 'A. ' + passage + ' First tail. B. ' + passage + ' Second tail.'
+    const second = page.lastIndexOf(passage)
+    const quote = filler + 'a caption sits here ' + filler + 'the end of it.'
+    const r = resolveTextAnchor(page, {
+      text: quote,
+      context: { offset: second, suffix: 'Second tail.' },
+    })
+    expect(r).toMatchObject({ kind: 'placed', via: 'ends', start: second })
+    expect(resolveTextAnchor(page, { text: quote })).toEqual({ kind: 'ambiguous' })
+  })
+
+  it('maps a leading dropped citation into the first character span', () => {
+    const r = normalizeForMatch('[40] Intro')
+    expect(r.text).toBe('Intro')
+    expect(r.starts[0]).toBe(0)
+    expect(r.dropped).toMatchObject([{ at: 0, from: 0, to: 4, value: '40', bracketed: true }])
+  })
+
   it('refuses to guess between unhinted repeats', () => {
     expect(findBestTextMatch('Alpha target. Beta target.', 'target')).toBeUndefined()
     expect(resolveTextAnchor('Alpha target. Beta target.', { text: 'target' })).toEqual({

--- a/shared/highlight-source.ts
+++ b/shared/highlight-source.ts
@@ -99,78 +99,173 @@ export function boundaryAt(
 	return { node: last.node, offset: last.node.length };
 }
 
+export interface AnchorContext {
+	offset?: number;
+	prefix?: string;
+	suffix?: string;
+}
+
+export interface TextAnchor {
+	text: string;
+	hint?: { start: number; end: number };
+	context?: AnchorContext;
+}
+
+export type AnchorResolution =
+	| { kind: 'placed'; start: number; end: number; via: 'hint' | 'search' }
+	| { kind: 'ambiguous' }
+	| { kind: 'missing' };
+
+/** `starts[i]`/`ends[i]` map `text[i]` to a source span; a dropped citation folds into the span before it. */
+export interface NormalizedText {
+	text: string;
+	starts: number[];
+	ends: number[];
+}
+
+const FOLD: Record<string, string> = {
+	' ': ' ',
+	'’': "'",
+	'‘': "'",
+	'“': '"',
+	'”': '"',
+	'–': '-',
+	'—': '-'
+};
+const CITATION_LEAD = new Set(['.', ',', ';', ':', '!', '?', ')', '"', "'"]);
+const NO_SPACE_BEFORE = new Set(["'", ',', '.', ';', ':', '!', '?', ')']);
+const BRACKET_CITATION = /^\[\d{1,3}\]/;
+const BARE_CITATION = /^\d{1,3}(?=$|\s|[.,;:!?)\]])/;
+const MAX_HINT_DRIFT = 400;
+const MIN_SEPARATION = 64;
+
+export function normalizeForMatch(input: string): NormalizedText {
+	const text: string[] = [];
+	const starts: number[] = [];
+	const ends: number[] = [];
+	let pendingSpaceAt = -1;
+	const extendLast = (to: number) => {
+		if (ends.length > 0) ends[ends.length - 1] = to;
+	};
+	let i = 0;
+	while (i < input.length) {
+		const raw = input[i]!;
+		const ch = FOLD[raw] ?? raw;
+		if (/\s/.test(ch)) {
+			if (pendingSpaceAt === -1) pendingSpaceAt = i;
+			i += 1;
+			continue;
+		}
+		const bracket = BRACKET_CITATION.exec(input.slice(i, i + 5));
+		if (bracket) {
+			extendLast(i + bracket[0].length);
+			i += bracket[0].length;
+			continue;
+		}
+		const last = text.at(-1);
+		const beforeLast = text.at(-2);
+		if (
+			pendingSpaceAt === -1 &&
+			/\d/.test(ch) &&
+			last !== undefined &&
+			CITATION_LEAD.has(last) &&
+			!(beforeLast !== undefined && /\d/.test(beforeLast))
+		) {
+			const bare = BARE_CITATION.exec(input.slice(i, i + 16));
+			if (bare) {
+				extendLast(i + bare[0].length);
+				i += bare[0].length;
+				continue;
+			}
+		}
+		if (pendingSpaceAt !== -1) {
+			if (text.length > 0 && !NO_SPACE_BEFORE.has(ch)) {
+				text.push(' ');
+				starts.push(pendingSpaceAt);
+				ends.push(i);
+			} else {
+				extendLast(i);
+			}
+			pendingSpaceAt = -1;
+		}
+		text.push(ch);
+		starts.push(i);
+		ends.push(i + 1);
+		i += 1;
+	}
+	return { text: text.join(''), starts, ends };
+}
+
+/** `undefined` for no occurrence and for repeats that no hint separates. */
 export function findBestTextMatch(
 	source: string,
 	needle: string,
-	locator?: Pick<SourceLocatorPayload, 'offset' | 'prefix' | 'suffix'>
+	context?: AnchorContext
 ): { start: number; end: number } | undefined {
-	const normalizedNeedle = normalizeWhitespace(needle);
-	if (!normalizedNeedle) return undefined;
+	const src = normalizeForMatch(source);
+	const ndl = normalizeForMatch(needle).text;
+	if (!ndl) return undefined;
 
-	const starts = findCandidateMatches(source, normalizedNeedle);
-	if (starts.length === 0) return undefined;
+	const candidates: number[] = [];
+	for (let at = src.text.indexOf(ndl); at !== -1; at = src.text.indexOf(ndl, at + 1)) {
+		candidates.push(at);
+	}
+	if (candidates.length === 0) return undefined;
 
-	const expected = locator?.offset;
-	let best = starts[0];
-	if (!best) return undefined;
-	let bestScore = Number.POSITIVE_INFINITY;
+	const toSource = (start: number) => ({
+		start: src.starts[start]!,
+		end: src.ends[start + ndl.length - 1]!
+	});
+	if (candidates.length === 1) return toSource(candidates[0]!);
 
-	for (const match of starts) {
-		let score = expected === undefined ? 0 : Math.abs(match.start - expected);
-		if (contextMatches(source, match.start, locator?.prefix, true)) score -= 1000;
-		if (contextMatches(source, match.end, locator?.suffix, false)) score -= 1000;
-		if (score < bestScore) {
-			best = match;
-			bestScore = score;
-		}
+	const prefix = normalizeForMatch(context?.prefix ?? '').text.slice(-40);
+	const suffix = normalizeForMatch(context?.suffix ?? '').text.slice(0, 40);
+	const expected = context?.offset;
+	const ranked = candidates
+		.map((start) => {
+			const end = start + ndl.length;
+			const before = src.text.slice(Math.max(0, start - prefix.length - 1), start).trimEnd();
+			const after = src.text.slice(end, end + suffix.length + 1).trimStart();
+			const contextHits =
+				(prefix && before.endsWith(prefix) ? 1 : 0) + (suffix && after.startsWith(suffix) ? 1 : 0);
+			const distance =
+				expected === undefined ? Infinity : Math.abs((src.starts[start] ?? 0) - expected);
+			return { start, contextHits, distance };
+		})
+		.sort((a, b) => b.contextHits - a.contextHits || a.distance - b.distance);
+	const best = ranked[0]!;
+	const second = ranked[1]!;
+	if (best.contextHits > second.contextHits) return toSource(best.start);
+	if (best.distance <= MAX_HINT_DRIFT && second.distance >= best.distance + MIN_SEPARATION) {
+		return toSource(best.start);
+	}
+	return undefined;
+}
+
+export function resolveTextAnchor(sourceText: string, anchor: TextAnchor): AnchorResolution {
+	const expected = normalizeForMatch(anchor.text).text;
+	if (!expected) return { kind: 'missing' };
+
+	const hint = anchor.hint;
+	if (hint && hint.end > hint.start) {
+		const found = normalizeForMatch(sourceText.slice(hint.start, hint.end)).text;
+		if (found === expected)
+			return { kind: 'placed', start: hint.start, end: hint.end, via: 'hint' };
 	}
 
-	return best;
+	const context = {
+		...anchor.context,
+		offset: anchor.context?.offset ?? hint?.start
+	};
+	const match = findBestTextMatch(sourceText, anchor.text, context);
+	if (match) return { kind: 'placed', ...match, via: 'search' };
+	return normalizeForMatch(sourceText).text.includes(expected)
+		? { kind: 'ambiguous' }
+		: { kind: 'missing' };
 }
 
 export function normalizeWhitespace(value: string): string {
 	return value.replace(/\s+/g, ' ').trim();
-}
-
-function findCandidateMatches(
-	source: string,
-	normalizedNeedle: string
-): Array<{
-	start: number;
-	end: number;
-}> {
-	const pattern = escapeRegExp(normalizedNeedle).replace(/\s+/g, '\\s+');
-	const regex = new RegExp(pattern, 'g');
-	const matches: Array<{ start: number; end: number }> = [];
-
-	let match = regex.exec(source);
-	while (match) {
-		matches.push({ start: match.index, end: match.index + match[0].length });
-		if (match[0].length === 0) regex.lastIndex += 1;
-		match = regex.exec(source);
-	}
-
-	return matches;
-}
-
-function contextMatches(
-	source: string,
-	offset: number,
-	context: string | undefined,
-	before: boolean
-): boolean {
-	const normalized = normalizeWhitespace(context ?? '');
-	if (!normalized) return false;
-
-	const sample = before
-		? normalizeWhitespace(source.slice(Math.max(0, offset - normalized.length - 40), offset))
-		: normalizeWhitespace(source.slice(offset, Math.min(source.length, offset + normalized.length + 40)));
-
-	return before ? sample.endsWith(normalized.slice(-40)) : sample.startsWith(normalized.slice(0, 40));
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/shared/highlight-source.ts
+++ b/shared/highlight-source.ts
@@ -112,7 +112,7 @@ export interface TextAnchor {
 }
 
 export type AnchorResolution =
-	| { kind: 'placed'; start: number; end: number; via: 'hint' | 'search' }
+	| { kind: 'placed'; start: number; end: number; via: 'hint' | 'search' | 'ends' }
 	| { kind: 'ambiguous' }
 	| { kind: 'missing' };
 
@@ -134,8 +134,11 @@ const FOLD: Record<string, string> = {
 };
 const CITATION_LEAD = new Set(['.', ',', ';', ':', '!', '?', ')', '"', "'"]);
 const NO_SPACE_BEFORE = new Set(["'", ',', '.', ';', ':', '!', '?', ')']);
-const BRACKET_CITATION = /^\[\d{1,3}\]/;
+const BRACKET_CITATION = /^\[(?:\d{1,3}|[a-z]{2,3})\]/;
 const BARE_CITATION = /^\d{1,3}(?=$|\s|[.,;:!?)\]])/;
+const CHAINED_CITATION = /^\s*\d{1,3}(?=$|\s|[.,;:!?)\]])/;
+const ENDS_MIN_LENGTH = 120;
+const ENDS_ANCHOR = 48;
 const MAX_HINT_DRIFT = 400;
 const MIN_SEPARATION = 64;
 
@@ -158,8 +161,7 @@ export function normalizeForMatch(input: string): NormalizedText {
 		}
 		const bracket = BRACKET_CITATION.exec(input.slice(i, i + 5));
 		if (bracket) {
-			extendLast(i + bracket[0].length);
-			i += bracket[0].length;
+			i = swallowCitationRun(input, i + bracket[0].length, extendLast);
 			continue;
 		}
 		const last = text.at(-1);
@@ -173,8 +175,7 @@ export function normalizeForMatch(input: string): NormalizedText {
 		) {
 			const bare = BARE_CITATION.exec(input.slice(i, i + 16));
 			if (bare) {
-				extendLast(i + bare[0].length);
-				i += bare[0].length;
+				i = swallowCitationRun(input, i + bare[0].length, extendLast);
 				continue;
 			}
 		}
@@ -194,6 +195,17 @@ export function normalizeForMatch(input: string): NormalizedText {
 		i += 1;
 	}
 	return { text: text.join(''), starts, ends };
+}
+
+function swallowCitationRun(input: string, from: number, extendLast: (to: number) => void): number {
+	let at = from;
+	for (;;) {
+		const more = CHAINED_CITATION.exec(input.slice(at, at + 16));
+		if (!more || /^\s*$/.test(more[0])) break;
+		at += more[0].length;
+	}
+	extendLast(at);
+	return at;
 }
 
 /** `undefined` for no occurrence and for repeats that no hint separates. */
@@ -259,9 +271,61 @@ export function resolveTextAnchor(sourceText: string, anchor: TextAnchor): Ancho
 	};
 	const match = findBestTextMatch(sourceText, anchor.text, context);
 	if (match) return { kind: 'placed', ...match, via: 'search' };
-	return normalizeForMatch(sourceText).text.includes(expected)
-		? { kind: 'ambiguous' }
-		: { kind: 'missing' };
+	const src = normalizeForMatch(sourceText);
+	if (src.text.includes(expected)) return { kind: 'ambiguous' };
+	const ends = matchByEnds(src, expected, context);
+	if (ends === 'ambiguous') return { kind: 'ambiguous' };
+	if (ends) return { kind: 'placed', ...ends, via: 'ends' };
+	return { kind: 'missing' };
+}
+
+/** Long quotes drift in the middle (dropped markers, reflowed captions); anchor the two ends instead. */
+function matchByEnds(
+	src: NormalizedText,
+	needle: string,
+	context: AnchorContext
+): { start: number; end: number } | 'ambiguous' | undefined {
+	if (needle.length < ENDS_MIN_LENGTH) return undefined;
+	const head = needle.slice(0, ENDS_ANCHOR);
+	const tail = needle.slice(-ENDS_ANCHOR);
+	const heads = occurrences(src.text, head);
+	const tails = occurrences(src.text, tail);
+	if (heads.length === 0 || tails.length === 0) return undefined;
+
+	const prefix = normalizeForMatch(context.prefix ?? '').text.slice(-40);
+	const pairs = heads
+		.map((h) => {
+			const t = tails.find((candidate) => candidate > h);
+			if (t === undefined) return undefined;
+			const length = t + tail.length - h;
+			const ratio = length / needle.length;
+			if (ratio < 0.6 || ratio > 1.5) return undefined;
+			const before = src.text.slice(Math.max(0, h - prefix.length - 1), h).trimEnd();
+			return {
+				h,
+				end: t + tail.length,
+				drift: Math.abs(length - needle.length),
+				context: prefix && before.endsWith(prefix) ? 1 : 0
+			};
+		})
+		.filter((pair): pair is NonNullable<typeof pair> => pair !== undefined)
+		.sort((a, b) => b.context - a.context || a.drift - b.drift);
+	const best = pairs[0];
+	if (!best) return undefined;
+	const second = pairs[1];
+	const margin = needle.length * 0.05;
+	if (second && second.context === best.context && second.drift - best.drift < margin) {
+		return 'ambiguous';
+	}
+	return { start: src.starts[best.h]!, end: src.ends[best.end - 1]! };
+}
+
+function occurrences(haystack: string, needle: string): number[] {
+	const found: number[] = [];
+	for (let at = haystack.indexOf(needle); at !== -1; at = haystack.indexOf(needle, at + 1)) {
+		found.push(at);
+	}
+	return found;
 }
 
 export function normalizeWhitespace(value: string): string {

--- a/shared/highlight-source.ts
+++ b/shared/highlight-source.ts
@@ -116,15 +116,25 @@ export type AnchorResolution =
 	| { kind: 'ambiguous' }
 	| { kind: 'missing' };
 
-/** `starts[i]`/`ends[i]` map `text[i]` to a source span; a dropped citation folds into the span before it. */
+/** `at` is the index in `text` the dropped token sat before. */
+export interface DroppedCitation {
+	at: number;
+	from: number;
+	to: number;
+	value: string;
+	bracketed: boolean;
+}
+
+/** `starts[i]`/`ends[i]` map `text[i]` to a source span; dropped citations fold into the neighbouring span. */
 export interface NormalizedText {
 	text: string;
 	starts: number[];
 	ends: number[];
+	dropped: DroppedCitation[];
 }
 
 const FOLD: Record<string, string> = {
-	' ': ' ',
+	' ': ' ',
 	'’': "'",
 	'‘': "'",
 	'“': '"',
@@ -134,9 +144,9 @@ const FOLD: Record<string, string> = {
 };
 const CITATION_LEAD = new Set(['.', ',', ';', ':', '!', '?', ')', '"', "'"]);
 const NO_SPACE_BEFORE = new Set(["'", ',', '.', ';', ':', '!', '?', ')']);
-const BRACKET_CITATION = /^\[(?:\d{1,3}|[a-z]{2,3})\]/;
+const BRACKET_CITATION = /^\[(\d{1,3}|[a-z]{2,3})\]/;
 const BARE_CITATION = /^\d{1,3}(?=$|\s|[.,;:!?)\]])/;
-const CHAINED_CITATION = /^\s*\d{1,3}(?=$|\s|[.,;:!?)\]])/;
+const CHAINED_CITATION = /^\s*(\d{1,3})(?=$|\s|[.,;:!?)\]])/;
 const ENDS_MIN_LENGTH = 120;
 const ENDS_ANCHOR = 48;
 const MAX_HINT_DRIFT = 400;
@@ -146,9 +156,13 @@ export function normalizeForMatch(input: string): NormalizedText {
 	const text: string[] = [];
 	const starts: number[] = [];
 	const ends: number[] = [];
+	const dropped: DroppedCitation[] = [];
 	let pendingSpaceAt = -1;
-	const extendLast = (to: number) => {
+	let leadingDropAt = -1;
+	const drop = (from: number, to: number, value: string, bracketed: boolean) => {
+		dropped.push({ at: text.length, from, to, value, bracketed });
 		if (ends.length > 0) ends[ends.length - 1] = to;
+		else if (leadingDropAt === -1) leadingDropAt = from;
 	};
 	let i = 0;
 	while (i < input.length) {
@@ -161,7 +175,7 @@ export function normalizeForMatch(input: string): NormalizedText {
 		}
 		const bracket = BRACKET_CITATION.exec(input.slice(i, i + 5));
 		if (bracket) {
-			i = swallowCitationRun(input, i + bracket[0].length, extendLast);
+			i = swallowCitationRun(input, i, i + bracket[0].length, bracket[1]!, true, drop);
 			continue;
 		}
 		const last = text.at(-1);
@@ -175,7 +189,7 @@ export function normalizeForMatch(input: string): NormalizedText {
 		) {
 			const bare = BARE_CITATION.exec(input.slice(i, i + 16));
 			if (bare) {
-				i = swallowCitationRun(input, i + bare[0].length, extendLast);
+				i = swallowCitationRun(input, i, i + bare[0].length, bare[0], false, drop);
 				continue;
 			}
 		}
@@ -184,28 +198,121 @@ export function normalizeForMatch(input: string): NormalizedText {
 				text.push(' ');
 				starts.push(pendingSpaceAt);
 				ends.push(i);
-			} else {
-				extendLast(i);
+			} else if (ends.length > 0) {
+				ends[ends.length - 1] = i;
 			}
 			pendingSpaceAt = -1;
 		}
 		text.push(ch);
-		starts.push(i);
+		starts.push(text.length === 1 && leadingDropAt !== -1 ? leadingDropAt : i);
 		ends.push(i + 1);
 		i += 1;
 	}
-	return { text: text.join(''), starts, ends };
+	return { text: text.join(''), starts, ends, dropped };
 }
 
-function swallowCitationRun(input: string, from: number, extendLast: (to: number) => void): number {
-	let at = from;
+function swallowCitationRun(
+	input: string,
+	from: number,
+	firstEnd: number,
+	firstValue: string,
+	bracketed: boolean,
+	drop: (from: number, to: number, value: string, bracketed: boolean) => void
+): number {
+	drop(from, firstEnd, firstValue, bracketed);
+	let at = firstEnd;
 	for (;;) {
 		const more = CHAINED_CITATION.exec(input.slice(at, at + 16));
-		if (!more || /^\s*$/.test(more[0])) break;
+		if (!more) break;
+		drop(at, at + more[0].length, more[1]!, false);
 		at += more[0].length;
 	}
-	extendLast(at);
 	return at;
+}
+
+/** Bare numbers that differ on both sides are real values, not renumbered citations. */
+function citationsCompatible(
+	quote: NormalizedText,
+	page: NormalizedText,
+	pageStart: number,
+	pageEnd: number
+): boolean {
+	const inSpan = page.dropped.filter((d) => d.at >= pageStart && d.at <= pageEnd);
+	const pairs = Math.min(quote.dropped.length, inSpan.length);
+	for (let k = 0; k < pairs; k += 1) {
+		const q = quote.dropped[k]!;
+		const p = inSpan[k]!;
+		if (!q.bracketed && !p.bracketed && q.value !== p.value) return false;
+	}
+	return true;
+}
+
+interface Candidate {
+	start: number;
+	end: number;
+	contextHits: number;
+	distance: number;
+}
+
+function rankCandidates(
+	src: NormalizedText,
+	starts: number[],
+	length: number,
+	context: AnchorContext | undefined
+): Candidate[] {
+	const prefix = normalizeForMatch(context?.prefix ?? '').text.slice(-40);
+	const suffix = normalizeForMatch(context?.suffix ?? '').text.slice(0, 40);
+	const expected = context?.offset;
+	return starts
+		.map((start) => {
+			const end = start + length;
+			const before = src.text.slice(Math.max(0, start - prefix.length - 1), start).trimEnd();
+			const after = src.text.slice(end, end + suffix.length + 1).trimStart();
+			const contextHits =
+				(prefix && before.endsWith(prefix) ? 1 : 0) + (suffix && after.startsWith(suffix) ? 1 : 0);
+			const distance =
+				expected === undefined ? Infinity : Math.abs((src.starts[start] ?? 0) - expected);
+			return { start, end, contextHits, distance };
+		})
+		.sort((a, b) => b.contextHits - a.contextHits || a.distance - b.distance);
+}
+
+function pickUnique(ranked: Candidate[]): Candidate | 'ambiguous' | undefined {
+	const best = ranked[0];
+	if (!best) return undefined;
+	if (ranked.length === 1) return best;
+	const second = ranked[1]!;
+	if (best.contextHits > second.contextHits) return best;
+	if (best.distance <= MAX_HINT_DRIFT && second.distance >= best.distance + MIN_SEPARATION) {
+		return best;
+	}
+	return 'ambiguous';
+}
+
+function searchExact(
+	src: NormalizedText,
+	quote: NormalizedText,
+	context: AnchorContext | undefined
+): Candidate | 'ambiguous' | undefined {
+	const starts = occurrences(src.text, quote.text).filter((at) =>
+		citationsCompatible(quote, src, at, at + quote.text.length)
+	);
+	return pickUnique(rankCandidates(src, starts, quote.text.length, context));
+}
+
+function toSource(
+	src: NormalizedText,
+	quote: NormalizedText,
+	start: number,
+	end: number
+): { start: number; end: number } {
+	const leading =
+		quote.dropped[0]?.at === 0
+			? src.dropped.find(
+					(d) => d.at === start || (d.at === start - 1 && src.text[start - 1] === ' ')
+				)
+			: undefined;
+	return { start: leading ? leading.from : src.starts[start]!, end: src.ends[end - 1]! };
 }
 
 /** `undefined` for no occurrence and for repeats that no hint separates. */
@@ -214,110 +321,76 @@ export function findBestTextMatch(
 	needle: string,
 	context?: AnchorContext
 ): { start: number; end: number } | undefined {
+	const quote = normalizeForMatch(needle);
+	if (!quote.text) return undefined;
 	const src = normalizeForMatch(source);
-	const ndl = normalizeForMatch(needle).text;
-	if (!ndl) return undefined;
-
-	const candidates: number[] = [];
-	for (let at = src.text.indexOf(ndl); at !== -1; at = src.text.indexOf(ndl, at + 1)) {
-		candidates.push(at);
-	}
-	if (candidates.length === 0) return undefined;
-
-	const toSource = (start: number) => ({
-		start: src.starts[start]!,
-		end: src.ends[start + ndl.length - 1]!
-	});
-	if (candidates.length === 1) return toSource(candidates[0]!);
-
-	const prefix = normalizeForMatch(context?.prefix ?? '').text.slice(-40);
-	const suffix = normalizeForMatch(context?.suffix ?? '').text.slice(0, 40);
-	const expected = context?.offset;
-	const ranked = candidates
-		.map((start) => {
-			const end = start + ndl.length;
-			const before = src.text.slice(Math.max(0, start - prefix.length - 1), start).trimEnd();
-			const after = src.text.slice(end, end + suffix.length + 1).trimStart();
-			const contextHits =
-				(prefix && before.endsWith(prefix) ? 1 : 0) + (suffix && after.startsWith(suffix) ? 1 : 0);
-			const distance =
-				expected === undefined ? Infinity : Math.abs((src.starts[start] ?? 0) - expected);
-			return { start, contextHits, distance };
-		})
-		.sort((a, b) => b.contextHits - a.contextHits || a.distance - b.distance);
-	const best = ranked[0]!;
-	const second = ranked[1]!;
-	if (best.contextHits > second.contextHits) return toSource(best.start);
-	if (best.distance <= MAX_HINT_DRIFT && second.distance >= best.distance + MIN_SEPARATION) {
-		return toSource(best.start);
-	}
-	return undefined;
+	const found = searchExact(src, quote, context);
+	return found && found !== 'ambiguous' ? toSource(src, quote, found.start, found.end) : undefined;
 }
 
 export function resolveTextAnchor(sourceText: string, anchor: TextAnchor): AnchorResolution {
-	const expected = normalizeForMatch(anchor.text).text;
-	if (!expected) return { kind: 'missing' };
+	const quote = normalizeForMatch(anchor.text);
+	if (!quote.text) return { kind: 'missing' };
 
 	const hint = anchor.hint;
 	if (hint && hint.end > hint.start) {
-		const found = normalizeForMatch(sourceText.slice(hint.start, hint.end)).text;
-		if (found === expected)
+		const found = normalizeForMatch(sourceText.slice(hint.start, hint.end));
+		if (found.text === quote.text && citationsCompatible(quote, found, 0, found.text.length)) {
 			return { kind: 'placed', start: hint.start, end: hint.end, via: 'hint' };
+		}
 	}
 
 	const context = {
 		...anchor.context,
 		offset: anchor.context?.offset ?? hint?.start
 	};
-	const match = findBestTextMatch(sourceText, anchor.text, context);
-	if (match) return { kind: 'placed', ...match, via: 'search' };
 	const src = normalizeForMatch(sourceText);
-	if (src.text.includes(expected)) return { kind: 'ambiguous' };
-	const ends = matchByEnds(src, expected, context);
+	const exact = searchExact(src, quote, context);
+	if (exact === 'ambiguous') return { kind: 'ambiguous' };
+	if (exact)
+		return { kind: 'placed', ...toSource(src, quote, exact.start, exact.end), via: 'search' };
+	const ends = matchByEnds(src, quote, context);
 	if (ends === 'ambiguous') return { kind: 'ambiguous' };
-	if (ends) return { kind: 'placed', ...ends, via: 'ends' };
+	if (ends) return { kind: 'placed', ...toSource(src, quote, ends.start, ends.end), via: 'ends' };
 	return { kind: 'missing' };
 }
 
 /** Long quotes drift in the middle (dropped markers, reflowed captions); anchor the two ends instead. */
 function matchByEnds(
 	src: NormalizedText,
-	needle: string,
+	quote: NormalizedText,
 	context: AnchorContext
-): { start: number; end: number } | 'ambiguous' | undefined {
+): Candidate | 'ambiguous' | undefined {
+	const needle = quote.text;
 	if (needle.length < ENDS_MIN_LENGTH) return undefined;
 	const head = needle.slice(0, ENDS_ANCHOR);
 	const tail = needle.slice(-ENDS_ANCHOR);
 	const heads = occurrences(src.text, head);
 	const tails = occurrences(src.text, tail);
-	if (heads.length === 0 || tails.length === 0) return undefined;
-
-	const prefix = normalizeForMatch(context.prefix ?? '').text.slice(-40);
-	const pairs = heads
-		.map((h) => {
-			const t = tails.find((candidate) => candidate > h);
-			if (t === undefined) return undefined;
-			const length = t + tail.length - h;
-			const ratio = length / needle.length;
-			if (ratio < 0.6 || ratio > 1.5) return undefined;
-			const before = src.text.slice(Math.max(0, h - prefix.length - 1), h).trimEnd();
-			return {
-				h,
-				end: t + tail.length,
-				drift: Math.abs(length - needle.length),
-				context: prefix && before.endsWith(prefix) ? 1 : 0
-			};
-		})
-		.filter((pair): pair is NonNullable<typeof pair> => pair !== undefined)
-		.sort((a, b) => b.context - a.context || a.drift - b.drift);
+	const pairs: Array<Candidate & { drift: number }> = [];
+	for (const h of heads) {
+		for (const t of tails) {
+			if (t <= h) continue;
+			const end = t + tail.length;
+			const ratio = (end - h) / needle.length;
+			if (ratio < 0.6 || ratio > 1.5) continue;
+			if (!citationsCompatible(quote, src, h, end)) continue;
+			const [ranked] = rankCandidates(src, [h], end - h, context);
+			pairs.push({ ...ranked!, drift: Math.abs(end - h - needle.length) });
+		}
+	}
+	pairs.sort(
+		(a, b) => b.contextHits - a.contextHits || a.distance - b.distance || a.drift - b.drift
+	);
 	const best = pairs[0];
 	if (!best) return undefined;
 	const second = pairs[1];
-	const margin = needle.length * 0.05;
-	if (second && second.context === best.context && second.drift - best.drift < margin) {
-		return 'ambiguous';
-	}
-	return { start: src.starts[best.h]!, end: src.ends[best.end - 1]! };
+	if (!second || second.contextHits < best.contextHits) return best;
+	const separated =
+		context.offset === undefined
+			? second.drift - best.drift >= needle.length * 0.05
+			: second.distance >= best.distance + MIN_SEPARATION;
+	return separated ? best : 'ambiguous';
 }
 
 function occurrences(haystack: string, needle: string): number[] {

--- a/shared/highlight-source.ts
+++ b/shared/highlight-source.ts
@@ -144,7 +144,8 @@ const FOLD: Record<string, string> = {
 };
 const CITATION_LEAD = new Set(['.', ',', ';', ':', '!', '?', ')', '"', "'"]);
 const NO_SPACE_BEFORE = new Set(["'", ',', '.', ';', ':', '!', '?', ')']);
-const BRACKET_CITATION = /^\[(\d{1,3}|[a-z]{2,3})\]/;
+const BRACKET_CITATION = /^\[(\d{1,3}|[a-z]{2,3})(?:\]|$)/;
+const CUT_LEADING_CITATION = /^(\d{1,3})\]/;
 const BARE_CITATION = /^\d{1,3}(?=$|\s|[.,;:!?)\]])/;
 const CHAINED_CITATION = /^\s*(\d{1,3})(?=$|\s|[.,;:!?)\]])/;
 const ENDS_MIN_LENGTH = 120;
@@ -165,6 +166,10 @@ export function normalizeForMatch(input: string): NormalizedText {
 		else if (leadingDropAt === -1) leadingDropAt = from;
 	};
 	let i = 0;
+	const cutLeading = CUT_LEADING_CITATION.exec(input);
+	if (cutLeading) {
+		i = swallowCitationRun(input, 0, cutLeading[0].length, cutLeading[1]!, true, drop);
+	}
 	while (i < input.length) {
 		const raw = input[i]!;
 		const ch = FOLD[raw] ?? raw;


### PR DESCRIPTION
- normalizeForMatch: span maps, citation runs, language markers, cut citations, quote/dash folding
- dropped citations tracked so bare numbers that differ stay distinct
- findBestTextMatch ranks context above offset distance and refuses ambiguous repeats
- resolveTextAnchor: verify hint, exact search, then head/tail anchoring for long quotes
- additive; no consumer changes