### PR TITLE
fix(extension): anchor highlights by tolerant text match

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -747,7 +747,7 @@ async function handleSelectionHighlight(tab?: Browser.tabs.Tab): Promise<void> {
     return
   }
 
-  const locator = await buildReaderLocator(libraryEntryId, selection)
+  const locator = await buildReaderLocator(activeTab.id, libraryEntryId, selection)
   serverUrl = await getServerUrl()
   if (!canExtensionSaveUrl(selection.sourceLocator.url, serverUrl)) {
     await setActionIdle(activeTab.id)
@@ -769,20 +769,26 @@ async function findSavedEntryForUrl(url: string): Promise<string | undefined> {
 }
 
 async function buildReaderLocator(
+  tabId: number,
   libraryEntryId: string,
   selection: SelectionPayload,
 ): Promise<LocatorPayload | undefined> {
-  const html = await fetchReadableHtml(libraryEntryId)
-  if (html === undefined) return undefined
-
-  const text = htmlToText(html)
-  const match = findUniqueNormalizedMatch(text, selection.text)
-  if (!match) return undefined
-
-  return {
-    type: 'html',
-    start_offset: match.start,
-    end_offset: match.end,
+  try {
+    const readableHtml = await fetchReadableHtml(libraryEntryId)
+    if (readableHtml === undefined) return undefined
+    const result = (await browser.tabs.sendMessage(tabId, {
+      action: 'locator:resolve',
+      payload: {
+        readableHtml,
+        text: selection.text,
+        prefix: selection.sourceLocator.prefix,
+        suffix: selection.sourceLocator.suffix,
+      },
+    } satisfies CaptureMessage)) as CaptureMessage
+    return result.action === 'locator:result' ? result.locator : undefined
+  } catch (error) {
+    reportBestEffortFailure('reader locator', error)
+    return undefined
   }
 }
 
@@ -797,62 +803,6 @@ async function fetchReadableHtml(libraryEntryId: string): Promise<string | undef
   } catch {}
 
   return undefined
-}
-
-function htmlToText(html: string): string {
-  return html
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-}
-
-function findUniqueNormalizedMatch(
-  source: string,
-  needle: string,
-): { start: number; end: number } | undefined {
-  const sourceNorm = normalizeWithMap(source)
-  const needleNorm = normalizeWithMap(needle).text.trim()
-  if (!needleNorm) return undefined
-
-  const first = sourceNorm.text.indexOf(needleNorm)
-  if (first === -1) return undefined
-  if (sourceNorm.text.indexOf(needleNorm, first + needleNorm.length) !== -1) return undefined
-
-  const lastNormIndex = first + needleNorm.length - 1
-  return {
-    start: sourceNorm.map[first] ?? 0,
-    end: (sourceNorm.map[lastNormIndex] ?? source.length - 1) + 1,
-  }
-}
-
-function normalizeWithMap(input: string): { text: string; map: number[] } {
-  let text = ''
-  const map: number[] = []
-  let pendingSpace = false
-
-  for (let i = 0; i < input.length; i += 1) {
-    const char = input[i]
-    if (char === undefined) continue
-    if (/\s/.test(char)) {
-      pendingSpace = text.length > 0
-      continue
-    }
-    if (pendingSpace) {
-      text += ' '
-      map.push(i)
-      pendingSpace = false
-    }
-    text += char
-    map.push(i)
-  }
-
-  return { text, map }
 }
 
 async function setActionIdle(tabId: number): Promise<void> {

--- a/extension/entrypoints/full-archive.content.ts
+++ b/extension/entrypoints/full-archive.content.ts
@@ -15,6 +15,11 @@ import { nodePath } from '@/lib/dom-range'
 import { extractCoverUrl } from '@/lib/cover-image'
 import { renderToolbar } from '@/lib/full-archive-toolbar'
 import { escapeAttr, escapeHtml } from '@/lib/html'
+import { resolveReaderLocator, type ReaderLocatorInput } from '@/lib/reader-locator'
+
+function captureError(err: unknown): CaptureMessage {
+  return { action: 'capture:error', message: err instanceof Error ? err.message : String(err) }
+}
 
 export default defineContentScript({
   registration: 'runtime',
@@ -33,54 +38,38 @@ export default defineContentScript({
         _sender,
         sendResponse: (response: unknown) => void,
       ): boolean | undefined => {
-        if (
-          typeof message === 'object' &&
-          message !== null &&
-          (message as Record<string, unknown>)['action'] === 'indelible:ping'
-        ) {
-          sendResponse({ success: true })
-          return true
-        }
-        if (
-          typeof message === 'object' &&
-          message !== null &&
-          (message as Record<string, unknown>)['action'] === 'toolbar:render'
-        ) {
-          renderToolbar((message as { state?: unknown }).state)
-          sendResponse({ success: true })
-          return true
-        }
-        if (
-          typeof message === 'object' &&
-          message !== null &&
-          (message as Record<string, unknown>)['action'] === 'capture:run'
-        ) {
-          runCapture()
-            .then(sendResponse)
-            .catch((err: unknown) => {
-              const msg: CaptureMessage = {
-                action: 'capture:error',
-                message: err instanceof Error ? err.message : String(err),
-              }
-              sendResponse(msg)
-            })
-          return true
-        }
-        if (
-          typeof message === 'object' &&
-          message !== null &&
-          (message as Record<string, unknown>)['action'] === 'selection:capture'
-        ) {
-          try {
-            sendResponse(captureSelection())
-          } catch (err) {
-            const msg: CaptureMessage = {
-              action: 'capture:error',
-              message: err instanceof Error ? err.message : String(err),
+        const record =
+          typeof message === 'object' && message !== null
+            ? (message as Record<string, unknown>)
+            : undefined
+        switch (record?.action) {
+          case 'indelible:ping':
+            sendResponse({ success: true })
+            return true
+          case 'toolbar:render':
+            renderToolbar(record.state)
+            sendResponse({ success: true })
+            return true
+          case 'capture:run':
+            runCapture()
+              .then(sendResponse)
+              .catch((err: unknown) => sendResponse(captureError(err)))
+            return true
+          case 'selection:capture':
+            try {
+              sendResponse(captureSelection())
+            } catch (err) {
+              sendResponse(captureError(err))
             }
-            sendResponse(msg)
-          }
-          return true
+            return true
+          case 'locator:resolve':
+            sendResponse({
+              action: 'locator:result',
+              locator: resolveReaderLocator(record.payload as ReaderLocatorInput, new DOMParser()),
+            } satisfies CaptureMessage)
+            return true
+          default:
+            return undefined
         }
       },
     )

--- a/extension/lib/api/generated/types.gen.ts
+++ b/extension/lib/api/generated/types.gen.ts
@@ -2004,7 +2004,7 @@ export type SourceLocatorSchemaFlat = {
   suffix?: string | null
   text_content?: string | null
   /**
-   * Discriminator: "web_page_dom_range"
+   * Discriminator: "web_page_dom_range" or "text_quote"
    */
   type: string
   url?: string | null

--- a/extension/lib/capture.ts
+++ b/extension/lib/capture.ts
@@ -2,6 +2,8 @@
 // Using a discriminated union eliminates the need for runtime casts elsewhere.
 
 import type { SourceLocatorPayload } from '../../shared/highlight-source'
+import type { LocatorPayload } from './api'
+import type { ReaderLocatorInput } from './reader-locator'
 
 export type CaptureMessage =
   | { action: 'capture:run' }
@@ -10,6 +12,8 @@ export type CaptureMessage =
   | { action: 'capture:progress'; step: CaptureStep }
   | { action: 'capture:result'; payload: CapturePayload }
   | { action: 'capture:error'; message: string; payload?: CapturePayload }
+  | { action: 'locator:resolve'; payload: ReaderLocatorInput }
+  | { action: 'locator:result'; locator?: LocatorPayload }
 
 export type CaptureStep = 'thumbnail' | 'extracting' | 'singlefile' | 'uploading'
 
@@ -44,7 +48,8 @@ export function isCaptureMessage(value: unknown): value is CaptureMessage {
     value !== null &&
     'action' in value &&
     typeof (value as Record<string, unknown>)['action'] === 'string' &&
-    (String((value as Record<string, unknown>)['action']).startsWith('capture:') ||
-      String((value as Record<string, unknown>)['action']).startsWith('selection:'))
+    ['capture:', 'selection:', 'locator:'].some((prefix) =>
+      String((value as Record<string, unknown>)['action']).startsWith(prefix),
+    )
   )
 }

--- a/extension/lib/full-archive-toolbar-markup.ts
+++ b/extension/lib/full-archive-toolbar-markup.ts
@@ -90,6 +90,7 @@ export function toolbarMarkup(state: ToolbarState): string {
           ${BRAND_MARK}
           <a class="btn-text" href="${readerUrl}" target="_blank" rel="noopener noreferrer">Open reader${IC_ARROW_RIGHT}</a>
           ${highlightCount > 0 ? `<span class="count-pill">${escapeHtml(tPlural('toolbar_highlights', highlightCount))}</span>` : ''}
+          <span class="count-pill js-unplaced" hidden></span>
         </div>
         <div class="item">
           <span class="t">${escapeHtml(entry?.title ?? 'Saved page')}</span>

--- a/extension/lib/full-archive-toolbar.ts
+++ b/extension/lib/full-archive-toolbar.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from '@/lib/html'
+import { tPlural } from '@/lib/i18n'
 import { nodePath } from '@/lib/dom-range'
 import {
   clearProjectedHighlights,
@@ -116,21 +117,31 @@ function parseProjectedHighlight(value: unknown): ProjectedHighlight | undefined
   const textContent = record.text_content
   if (typeof textContent !== 'string') return undefined
 
-  const sourceLocator = parseSourceLocator(record.source_locator, textContent)
+  const locatorRecord = isRecord(record.source_locator) ? record.source_locator : undefined
+  if (locatorRecord?.type === 'text_quote') {
+    return {
+      id: typeof record.id === 'string' ? record.id : undefined,
+      color: typeof record.color === 'string' ? record.color : undefined,
+      text_content: textContent,
+      context: {
+        prefix: stringField(locatorRecord, 'prefix'),
+        suffix: stringField(locatorRecord, 'suffix'),
+      },
+    }
+  }
   return {
     id: typeof record.id === 'string' ? record.id : undefined,
     color: typeof record.color === 'string' ? record.color : undefined,
     text_content: textContent,
-    source_locator: sourceLocator,
+    source_locator: parseSourceLocator(locatorRecord, textContent),
   }
 }
 
 function parseSourceLocator(
-  value: unknown,
+  record: Record<string, unknown> | undefined,
   textContent: string,
 ): ProjectedHighlight['source_locator'] {
-  if (typeof value !== 'object' || value === null) return undefined
-  const record = value as Record<string, unknown>
+  if (!record) return undefined
   return {
     type: 'web_page_dom_range',
     url: stringField(record, 'url') ?? '',
@@ -478,9 +489,15 @@ function syncHighlightProjection(root: ShadowRoot, state: ToolbarState): void {
     return
   }
 
-  const projectedCount = projectHighlights(highlights)
-  if (projectedCount === 0) {
+  const result = projectHighlights(highlights)
+  if (result.placed === 0) {
     clearProjectedHighlights()
+  }
+  const unplaced = root.querySelector<HTMLElement>('.js-unplaced')
+  if (unplaced) {
+    unplaced.hidden = result.unplaced === 0
+    unplaced.textContent =
+      result.unplaced > 0 ? tPlural('toolbar_highlights_unplaced', result.unplaced) : ''
   }
   syncAutoHighlightToggle(root)
 }

--- a/extension/lib/highlight-projection.ts
+++ b/extension/lib/highlight-projection.ts
@@ -40,7 +40,8 @@ export function projectHighlights(
 
   ensureProjectionStyle(doc)
 
-  const index = buildTextIndex(doc.body ?? doc.documentElement, isPageTextNode)
+  const root = doc.body ?? doc.documentElement
+  const index = buildTextIndex(root, isPageTextNode)
   const resolved = projectable.map((highlight, i) => ({
     highlight,
     i,
@@ -48,14 +49,10 @@ export function projectHighlights(
   }))
   result.unplaced += resolved.filter((entry) => !entry.span).length
 
-  // Wrapping splits text nodes after the split point, so later spans are wrapped first.
-  const placeable = resolved
-    .filter(
-      (entry): entry is typeof entry & { span: { start: number; end: number } } => !!entry.span,
-    )
-    .sort((a, b) => b.span.start - a.span.start)
-  for (const { highlight, i, span } of placeable) {
-    const range = spanToRange(index, span, doc)
+  for (const { highlight, i, span } of resolved) {
+    if (!span) continue
+    // Wrapping splits text nodes, so each span is mapped on a fresh index; offsets are unaffected.
+    const range = spanToRange(buildTextIndex(root, isPageTextNode), span, doc)
     if (range && !range.collapsed && wrapTextRange(range, highlight, i, doc) > 0) {
       result.placed += 1
     } else {
@@ -118,19 +115,34 @@ function hintFromLocation(
   const endNode = resolveNodePath(parsed.endPath, doc)
   if (!startNode || !endNode) return undefined
 
+  const start = resolveBoundary(startNode, parsed.startOffset, false)
+  const end = resolveBoundary(endNode, parsed.endOffset, true)
+  if (!start || !end) return undefined
+
   try {
     const range = doc.createRange()
-    range.setStart(startNode, clampOffset(startNode, parsed.startOffset))
-    range.setEnd(endNode, clampOffset(endNode, parsed.endOffset))
+    range.setStart(start.node, start.offset)
+    range.setEnd(end.node, end.offset)
     return rangeToOffsets(index, range)
   } catch {
     return undefined
   }
 }
 
-function clampOffset(node: Node, offset: number): number {
-  const max = node.nodeType === Node.TEXT_NODE ? (node as Text).length : node.childNodes.length
-  return Math.min(Math.max(0, offset), max)
+/** Element containers carry a character offset into the element's text, not a child index. */
+function resolveBoundary(
+  node: Node,
+  offset: number,
+  preferEnd: boolean,
+): { node: Text; offset: number } | undefined {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node as Text
+    return { node: text, offset: Math.min(Math.max(0, offset), text.length) }
+  }
+  const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement
+  if (!element) return undefined
+  const local = buildTextIndex(element, isPageTextNode)
+  return boundaryAt(local.runs, Math.min(Math.max(0, offset), local.text.length), preferEnd)
 }
 
 function resolveNodePath(path: string, doc: Document): Node | undefined {
@@ -166,10 +178,6 @@ function spanToRange(
   }
 }
 
-function shouldWrapTextNode(node: Text): boolean {
-  return isPageTextNode(node) && node.parentElement?.closest(`[${MARK_ATTR}]`) === null
-}
-
 function wrapTextRange(
   range: Range,
   highlight: ProjectedHighlight,
@@ -200,7 +208,7 @@ function collectTextNodesInRange(root: Node, range: Range, doc: Document): Text[
   const nodes: Text[] = []
   const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
-      if (!shouldWrapTextNode(node as Text)) return NodeFilter.FILTER_REJECT
+      if (!isPageTextNode(node as Text)) return NodeFilter.FILTER_REJECT
       return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT
     },
   })

--- a/extension/lib/highlight-projection.ts
+++ b/extension/lib/highlight-projection.ts
@@ -1,11 +1,14 @@
 import {
   boundaryAt,
   buildTextIndex,
-  findBestTextMatch,
-  normalizeWhitespace,
   parseDomRangeLocation,
+  resolveTextAnchor,
+  type AnchorContext,
+  type AnchorResolution,
   type SourceLocatorPayload,
+  type TextIndex,
 } from '../../shared/highlight-source'
+import { isPageTextNode, rangeToOffsets } from './page-text'
 
 export type { SourceLocatorPayload } from '../../shared/highlight-source'
 
@@ -14,6 +17,12 @@ export interface ProjectedHighlight {
   color?: string
   text_content: string
   source_locator?: SourceLocatorPayload
+  context?: AnchorContext
+}
+
+export interface ProjectionResult {
+  placed: number
+  unplaced: number
 }
 
 const MARK_ATTR = 'data-indelible-highlight-id'
@@ -22,24 +31,39 @@ const STYLE_ID = 'indelible-highlight-projection-style'
 export function projectHighlights(
   highlights: ProjectedHighlight[],
   doc: Document = document,
-): number {
+): ProjectionResult {
   clearProjectedHighlights(doc)
 
   const projectable = highlights.filter((highlight) => highlight.text_content.trim().length > 0)
-  if (projectable.length === 0) return 0
+  const result: ProjectionResult = { placed: 0, unplaced: 0 }
+  if (projectable.length === 0) return result
 
   ensureProjectionStyle(doc)
 
-  let projectedCount = 0
-  for (const [index, highlight] of projectable.entries()) {
-    const range = resolveHighlightRange(highlight, doc)
-    if (!range || range.collapsed) continue
+  const index = buildTextIndex(doc.body ?? doc.documentElement, isPageTextNode)
+  const resolved = projectable.map((highlight, i) => ({
+    highlight,
+    i,
+    span: resolveHighlightSpan(highlight, index, doc),
+  }))
+  result.unplaced += resolved.filter((entry) => !entry.span).length
 
-    const wrapped = wrapTextRange(range, highlight, index, doc)
-    if (wrapped > 0) projectedCount += 1
+  // Wrapping splits text nodes after the split point, so later spans are wrapped first.
+  const placeable = resolved
+    .filter(
+      (entry): entry is typeof entry & { span: { start: number; end: number } } => !!entry.span,
+    )
+    .sort((a, b) => b.span.start - a.span.start)
+  for (const { highlight, i, span } of placeable) {
+    const range = spanToRange(index, span, doc)
+    if (range && !range.collapsed && wrapTextRange(range, highlight, i, doc) > 0) {
+      result.placed += 1
+    } else {
+      result.unplaced += 1
+    }
   }
 
-  return projectedCount
+  return result
 }
 
 export function clearProjectedHighlights(doc: Document = document): void {
@@ -55,19 +79,38 @@ export function clearProjectedHighlights(doc: Document = document): void {
   }
 }
 
-function resolveHighlightRange(highlight: ProjectedHighlight, doc: Document): Range | undefined {
-  const locator = highlight.source_locator
-  if (locator?.location) {
-    const located = resolveRangeFromLocation(locator, doc)
-    if (located && rangeMatchesHighlight(located, highlight.text_content)) {
-      return located
-    }
-  }
-
-  return resolveRangeFromText(highlight, doc)
+function resolveHighlightSpan(
+  highlight: ProjectedHighlight,
+  index: TextIndex,
+  doc: Document,
+): { start: number; end: number } | undefined {
+  const hint = hintFromLocation(highlight.source_locator, index, doc)
+  const context = highlight.context ?? highlight.source_locator
+  const resolution = resolveTextAnchor(index.text, {
+    text: highlight.text_content,
+    hint,
+    context: context
+      ? { offset: context.offset, prefix: context.prefix, suffix: context.suffix }
+      : undefined,
+  })
+  report(highlight.id, resolution)
+  return resolution.kind === 'placed' ? { start: resolution.start, end: resolution.end } : undefined
 }
 
-function resolveRangeFromLocation(locator: SourceLocatorPayload, doc: Document): Range | undefined {
+function report(id: string | undefined, resolution: AnchorResolution): void {
+  if (resolution.kind === 'placed' && resolution.via === 'hint') return
+  console.debug('[Indelible] highlight anchor', {
+    id,
+    stage: resolution.kind === 'placed' ? 'search' : resolution.kind,
+  })
+}
+
+function hintFromLocation(
+  locator: SourceLocatorPayload | undefined,
+  index: TextIndex,
+  doc: Document,
+): { start: number; end: number } | undefined {
+  if (!locator?.location) return undefined
   const parsed = parseDomRangeLocation(locator.location)
   if (!parsed) return undefined
 
@@ -75,18 +118,19 @@ function resolveRangeFromLocation(locator: SourceLocatorPayload, doc: Document):
   const endNode = resolveNodePath(parsed.endPath, doc)
   if (!startNode || !endNode) return undefined
 
-  const start = resolveBoundary(startNode, parsed.startOffset, false)
-  const end = resolveBoundary(endNode, parsed.endOffset, true)
-  if (!start || !end) return undefined
-
   try {
     const range = doc.createRange()
-    range.setStart(start.node, start.offset)
-    range.setEnd(end.node, end.offset)
-    return range
+    range.setStart(startNode, clampOffset(startNode, parsed.startOffset))
+    range.setEnd(endNode, clampOffset(endNode, parsed.endOffset))
+    return rangeToOffsets(index, range)
   } catch {
     return undefined
   }
+}
+
+function clampOffset(node: Node, offset: number): number {
+  const max = node.nodeType === Node.TEXT_NODE ? (node as Text).length : node.childNodes.length
+  return Math.min(Math.max(0, offset), max)
 }
 
 function resolveNodePath(path: string, doc: Document): Node | undefined {
@@ -103,34 +147,13 @@ function resolveNodePath(path: string, doc: Document): Node | undefined {
   return current
 }
 
-function resolveBoundary(
-  node: Node,
-  offset: number,
-  preferEnd: boolean,
-): { node: Text; offset: number } | undefined {
-  if (node.nodeType === Node.TEXT_NODE) {
-    const text = node as Text
-    return { node: text, offset: clamp(offset, 0, text.length) }
-  }
-
-  const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement
-  if (!element) return undefined
-
-  const index = buildTextIndex(element, shouldIndexTextNode)
-  return boundaryAt(index.runs, clamp(offset, 0, index.text.length), preferEnd)
-}
-
-function resolveRangeFromText(highlight: ProjectedHighlight, doc: Document): Range | undefined {
-  const needle = highlight.text_content.trim()
-  if (!needle) return undefined
-
-  const root = doc.body ?? doc.documentElement
-  const index = buildTextIndex(root, shouldIndexTextNode)
-  const match = findBestTextMatch(index.text, needle, highlight.source_locator)
-  if (!match) return undefined
-
-  const start = boundaryAt(index.runs, match.start, false)
-  const end = boundaryAt(index.runs, match.end, true)
+function spanToRange(
+  index: TextIndex,
+  span: { start: number; end: number },
+  doc: Document,
+): Range | undefined {
+  const start = boundaryAt(index.runs, span.start, false)
+  const end = boundaryAt(index.runs, span.end, true)
   if (!start || !end) return undefined
 
   try {
@@ -143,20 +166,8 @@ function resolveRangeFromText(highlight: ProjectedHighlight, doc: Document): Ran
   }
 }
 
-function rangeMatchesHighlight(range: Range, textContent: string): boolean {
-  const rangeText = normalizeWhitespace(range.toString())
-  const highlightText = normalizeWhitespace(textContent)
-  return rangeText === highlightText || rangeText.includes(highlightText)
-}
-
-function shouldIndexTextNode(node: Text): boolean {
-  const parent = node.parentElement
-  if (!parent) return false
-  return (
-    parent.closest(
-      `script, style, noscript, textarea, input, select, option, [contenteditable="true"], [${MARK_ATTR}]`,
-    ) === null
-  )
+function shouldWrapTextNode(node: Text): boolean {
+  return isPageTextNode(node) && node.parentElement?.closest(`[${MARK_ATTR}]`) === null
 }
 
 function wrapTextRange(
@@ -189,7 +200,7 @@ function collectTextNodesInRange(root: Node, range: Range, doc: Document): Text[
   const nodes: Text[] = []
   const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
-      if (!shouldIndexTextNode(node as Text)) return NodeFilter.FILTER_REJECT
+      if (!shouldWrapTextNode(node as Text)) return NodeFilter.FILTER_REJECT
       return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT
     },
   })
@@ -239,8 +250,4 @@ function ensureProjectionStyle(doc: Document): void {
     }
   `
   ;(doc.head ?? doc.documentElement).appendChild(style)
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value))
 }

--- a/extension/lib/page-text.ts
+++ b/extension/lib/page-text.ts
@@ -1,0 +1,76 @@
+import type { TextIndex } from '../../shared/highlight-source'
+
+const NON_CONTENT_SELECTOR =
+  'script, style, noscript, textarea, input, select, option, [contenteditable="true"], #indelible-toolbar-host'
+
+/** Includes text inside projected highlight marks; wrapping never changes the character sequence. */
+export function isPageTextNode(node: Text): boolean {
+  const parent = node.parentElement
+  if (!parent) return false
+  return parent.closest(NON_CONTENT_SELECTOR) === null
+}
+
+export function rangeToOffsets(
+  index: TextIndex,
+  range: Range,
+): { start: number; end: number } | undefined {
+  const start = boundaryOffset(index, range.startContainer, range.startOffset, false)
+  const end = boundaryOffset(index, range.endContainer, range.endOffset, true)
+  if (start === undefined || end === undefined || end < start) return undefined
+  return { start, end }
+}
+
+function boundaryOffset(
+  index: TextIndex,
+  container: Node,
+  offset: number,
+  preferEnd: boolean,
+): number | undefined {
+  if (container.nodeType === Node.TEXT_NODE) {
+    const run = index.runs.find((candidate) => candidate.node === container)
+    return run ? run.start + Math.min(offset, run.node.length) : undefined
+  }
+
+  const children = Array.from(container.childNodes)
+  const doc = container.ownerDocument
+  if (!doc) return undefined
+  const probe = doc.createRange()
+  if (preferEnd) {
+    const before = children[offset - 1]
+    if (!before) return firstRunAtOrAfter(index, container)
+    probe.selectNodeContents(before)
+    return lastRunInside(index, probe)
+  }
+  const after = children[offset]
+  if (!after) return lastRunInsideNode(index, container)
+  probe.selectNodeContents(after)
+  return firstRunInside(index, probe)
+}
+
+function firstRunInside(index: TextIndex, probe: Range): number | undefined {
+  const run = index.runs.find((candidate) => probe.intersectsNode(candidate.node))
+  return run?.start
+}
+
+function lastRunInside(index: TextIndex, probe: Range): number | undefined {
+  const run = [...index.runs].reverse().find((candidate) => probe.intersectsNode(candidate.node))
+  return run?.end
+}
+
+function firstRunAtOrAfter(index: TextIndex, container: Node): number | undefined {
+  const run = index.runs.find(
+    (candidate) =>
+      container.compareDocumentPosition(candidate.node) & Node.DOCUMENT_POSITION_CONTAINED_BY,
+  )
+  return run?.start
+}
+
+function lastRunInsideNode(index: TextIndex, container: Node): number | undefined {
+  const run = [...index.runs]
+    .reverse()
+    .find(
+      (candidate) =>
+        container.compareDocumentPosition(candidate.node) & Node.DOCUMENT_POSITION_CONTAINED_BY,
+    )
+  return run?.end
+}

--- a/extension/lib/reader-locator.ts
+++ b/extension/lib/reader-locator.ts
@@ -1,0 +1,27 @@
+import { buildTextIndex, resolveTextAnchor } from '../../shared/highlight-source'
+import type { LocatorPayload } from '@/lib/api'
+
+export interface ReaderLocatorInput {
+  readableHtml: string
+  text: string
+  prefix?: string
+  suffix?: string
+}
+
+function isReaderTextNode(node: Text): boolean {
+  return node.parentElement?.closest('script, style, noscript, template') === null
+}
+
+export function resolveReaderLocator(
+  input: ReaderLocatorInput,
+  parser: DOMParser,
+): LocatorPayload | undefined {
+  const doc = parser.parseFromString(input.readableHtml, 'text/html')
+  const index = buildTextIndex(doc.body, isReaderTextNode)
+  const resolution = resolveTextAnchor(index.text, {
+    text: input.text,
+    context: { prefix: input.prefix, suffix: input.suffix },
+  })
+  if (resolution.kind !== 'placed' || resolution.end <= resolution.start) return undefined
+  return { type: 'html', start_offset: resolution.start, end_offset: resolution.end }
+}

--- a/extension/public/_locales/en/messages.json
+++ b/extension/public/_locales/en/messages.json
@@ -67,6 +67,22 @@
       }
     }
   },
+  "toolbar_highlights_unplaced_one": {
+    "message": "$COUNT$ highlight couldn't be placed on this page",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "toolbar_highlights_unplaced_other": {
+    "message": "$COUNT$ highlights couldn't be placed on this page",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
   "toolbar_saved_ago": {
     "message": "saved $WHEN$",
     "placeholders": {

--- a/extension/public/_locales/fr/messages.json
+++ b/extension/public/_locales/fr/messages.json
@@ -67,6 +67,22 @@
       }
     }
   },
+  "toolbar_highlights_unplaced_one": {
+    "message": "$COUNT$ surlignage n'a pas pu être placé sur cette page",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "toolbar_highlights_unplaced_other": {
+    "message": "$COUNT$ surlignages n'ont pas pu être placés sur cette page",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
   "toolbar_saved_ago": {
     "message": "enregistré $WHEN$",
     "placeholders": {

--- a/extension/tests/background.test.ts
+++ b/extension/tests/background.test.ts
@@ -673,7 +673,7 @@ describe('background message handler', () => {
       expect(highlightWriteAttempted).toBe(false)
     })
 
-    it('uses flattened document asset responses to build reader locators', async () => {
+    async function highlightThroughReaderLocator(locatorFails: boolean) {
       const libraryEntryId = 'lib_018f2f1a-1111-7222-8333-111111111111'
       const tab = {
         id: 42,
@@ -681,6 +681,7 @@ describe('background message handler', () => {
         title: 'Reader article',
       }
       let highlightBody: unknown
+      let locatorRequest: unknown
 
       mockStorage['ind_server_url'] = 'https://test.useindelible.com'
       setAccessTokenMemory('jwt_token', FUTURE_EXPIRY)
@@ -699,6 +700,14 @@ describe('background message handler', () => {
                   text_content: 'selected phrase',
                 },
               },
+            }
+          }
+          if (message.action === 'locator:resolve') {
+            locatorRequest = (message as unknown as { payload: unknown }).payload
+            if (locatorFails) throw new Error('content script gone')
+            return {
+              action: 'locator:result',
+              locator: { type: 'html', start_offset: 7, end_offset: 22 },
             }
           }
           return undefined
@@ -792,21 +801,35 @@ describe('background message handler', () => {
         { action: 'toolbar:highlight-selection' },
         { id: EXTENSION_ID },
       )
+      return { response, highlightBody, locatorRequest, libraryEntryId }
+    }
+
+    it('asks the content script for a reader locator built from the readable asset', async () => {
+      const { response, highlightBody, locatorRequest, libraryEntryId } =
+        await highlightThroughReaderLocator(false)
 
       expect(response.success).toBe(true)
+      expect(locatorRequest).toMatchObject({
+        readableHtml: '<article>Before selected phrase after.</article>',
+        text: 'selected phrase',
+      })
       expect(highlightBody).toMatchObject({
         color: 'yellow',
         text_content: 'selected phrase',
-        locator: {
-          type: 'html',
-          start_offset: 7,
-          end_offset: 22,
-        },
+        locator: { type: 'html', start_offset: 7, end_offset: 22 },
       })
       expect(fetchMock).not.toHaveBeenCalledWith(
         expect.stringContaining(`/api/v1/assets/${libraryEntryId}/readable_html`),
         expect.anything(),
       )
+    })
+
+    it('still writes the highlight when the reader locator cannot be resolved', async () => {
+      const { response, highlightBody } = await highlightThroughReaderLocator(true)
+
+      expect(response.success).toBe(true)
+      expect(highlightBody).toMatchObject({ color: 'yellow', text_content: 'selected phrase' })
+      expect((highlightBody as { locator?: unknown }).locator).toBeUndefined()
     })
   })
 })

--- a/extension/tests/full-archive-toolbar.test.ts
+++ b/extension/tests/full-archive-toolbar.test.ts
@@ -216,4 +216,19 @@ describe('full archive toolbar', () => {
 
     await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledWith({ action: 'toolbar:save' }))
   })
+
+  it('reports highlights that could not be placed on the page', () => {
+    renderToolbar({
+      ...savedState(),
+      highlights: [
+        { id: 'h_1', text_content: 'Alpha' },
+        { id: 'h_2', text_content: 'absent phrase' },
+      ],
+    })
+
+    const pill = toolbarRoot().querySelector<HTMLElement>('.js-unplaced')
+    expect(pill?.hidden).toBe(false)
+    expect(pill?.textContent).toBe("1 highlight couldn't be placed on this page")
+    expect(document.querySelectorAll('mark.indelible-projected-highlight')).toHaveLength(1)
+  })
 })

--- a/extension/tests/highlight-projection.test.ts
+++ b/extension/tests/highlight-projection.test.ts
@@ -29,7 +29,7 @@ describe('highlight projection', () => {
       },
     }
 
-    expect(projectHighlights([highlight], document)).toBe(1)
+    expect(projectHighlights([highlight], document)).toEqual({ placed: 1, unplaced: 0 })
 
     const mark = document.querySelector('mark.indelible-projected-highlight')
     expect(mark?.textContent).toBe('brave')
@@ -52,7 +52,7 @@ describe('highlight projection', () => {
       },
     }
 
-    expect(projectHighlights([highlight], document)).toBe(1)
+    expect(projectHighlights([highlight], document)).toEqual({ placed: 1, unplaced: 0 })
 
     const paragraphs = Array.from(document.querySelectorAll('p'))
     expect(paragraphs[0]?.querySelector('mark')).toBeNull()
@@ -76,7 +76,7 @@ describe('highlight projection', () => {
       },
     }
 
-    expect(projectHighlights([highlight], document)).toBe(1)
+    expect(projectHighlights([highlight], document)).toEqual({ placed: 1, unplaced: 0 })
 
     const paragraphs = Array.from(document.querySelectorAll('p'))
     expect(paragraphs[0]?.querySelector('mark')).toBeNull()
@@ -91,5 +91,49 @@ describe('highlight projection', () => {
 
     expect(document.querySelector('mark.indelible-projected-highlight')).toBeNull()
     expect(document.body.innerHTML).toBe('<p>Hello brave world.</p>')
+  })
+
+  it('projects a reader-created highlight whose citation numbering differs from the page', () => {
+    document.body.innerHTML =
+      '<p>Paxson filed notes daily.<sup>[34]</sup> The notes were ordered.</p>'
+
+    const result = projectHighlights(
+      [{ id: 'h_5', text_content: 'Paxson filed notes daily.39 The notes were ordered.' }],
+      document,
+    )
+
+    expect(result).toEqual({ placed: 1, unplaced: 0 })
+    expect(document.querySelector('mark')?.textContent).toContain('Paxson filed notes daily.')
+  })
+
+  it('counts an unhinted repeated phrase as unplaced instead of guessing', () => {
+    document.body.innerHTML = '<p>Alpha target.</p><p>Beta target.</p>'
+
+    expect(projectHighlights([{ id: 'h_6', text_content: 'target' }], document)).toEqual({
+      placed: 0,
+      unplaced: 1,
+    })
+    expect(document.querySelector('mark')).toBeNull()
+  })
+
+  it('keeps earlier highlights intact when several share one text node', () => {
+    document.body.innerHTML = '<p>one two three four five</p>'
+
+    const result = projectHighlights(
+      [
+        { id: 'a', text_content: 'one' },
+        { id: 'b', text_content: 'three' },
+        { id: 'c', text_content: 'five' },
+      ],
+      document,
+    )
+
+    expect(result).toEqual({ placed: 3, unplaced: 0 })
+    expect(Array.from(document.querySelectorAll('mark')).map((mark) => mark.textContent)).toEqual([
+      'one',
+      'three',
+      'five',
+    ])
+    expect(document.body.textContent).toBe('one two three four five')
   })
 })

--- a/extension/tests/highlight-projection.test.ts
+++ b/extension/tests/highlight-projection.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   clearProjectedHighlights,
@@ -14,6 +14,7 @@ describe('highlight projection', () => {
   })
 
   it('projects a highlight from a parent-element DOM location', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
     document.body.innerHTML = '<p>Hello brave world.</p>'
 
     const highlight: ProjectedHighlight = {
@@ -34,6 +35,29 @@ describe('highlight projection', () => {
     const mark = document.querySelector('mark.indelible-projected-highlight')
     expect(mark?.textContent).toBe('brave')
     expect(document.body.textContent).toBe('Hello brave world.')
+    expect(debug).not.toHaveBeenCalled()
+    debug.mockRestore()
+  })
+
+  it('covers overlapping highlights fully by nesting marks', () => {
+    document.body.innerHTML = '<p>abcdefghij</p>'
+
+    const result = projectHighlights(
+      [
+        { id: 'a', text_content: 'cdefgh' },
+        { id: 'b', text_content: 'fghi' },
+      ],
+      document,
+    )
+
+    expect(result).toEqual({ placed: 2, unplaced: 0 })
+    const byId = (id: string) =>
+      Array.from(document.querySelectorAll(`mark[data-indelible-highlight-id="${id}"]`))
+        .map((mark) => mark.textContent)
+        .join('')
+    expect(byId('a')).toBe('cdefgh')
+    expect(byId('b')).toBe('fghi')
+    expect(document.body.textContent).toBe('abcdefghij')
   })
 
   it('uses source offset to choose between repeated text matches', () => {

--- a/extension/tests/reader-locator.test.ts
+++ b/extension/tests/reader-locator.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { resolveReaderLocator } from '../lib/reader-locator'
+
+const html = `<article><h1>Zettelkasten</h1><p><a href="#">Antonin Sertillanges</a> ' book <i>The Intellectual Life</i> (1921) outlines.<sup id="ind-fnref:28"><a href="#ind-fn:28">28</a></sup></p><p>Later edited in a final form.<sup><a href="#">40</a></sup> French theorist.</p></article>`
+
+describe('resolveReaderLocator', () => {
+  const parser = new DOMParser()
+
+  it('resolves live-page text with bracketed citations against readable html', () => {
+    const loc = resolveReaderLocator(
+      { readableHtml: html, text: 'Later edited in a final form.[35]' },
+      parser,
+    )
+    expect(loc).toBeDefined()
+    const body = parser.parseFromString(html, 'text/html').body.textContent!
+    expect(body.slice(loc!.start_offset, loc!.end_offset)).toBe('Later edited in a final form.40')
+  })
+
+  it('resolves across a spaced apostrophe', () => {
+    const loc = resolveReaderLocator(
+      { readableHtml: html, text: "Sertillanges' book The Intellectual Life" },
+      parser,
+    )
+    expect(loc).toBeDefined()
+    expect(loc!.end_offset).toBeGreaterThan(loc!.start_offset)
+  })
+
+  it('returns undefined for page chrome that is not in the article', () => {
+    expect(
+      resolveReaderLocator({ readableHtml: html, text: 'Article Talk Read Edit' }, parser),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
- projection resolves hints through resolveTextAnchor and reports unplaced highlights
- overlapping highlights nest; element-offset locations honoured
- reader locator resolved in the content script from the readable DOM; failures no longer block the save
- depends on #30 and #31 (text_quote types regenerated)