### PR TITLE
fix(web): place highlights by verified text anchors

### DIFF
--- a/web/src/lib/api/generated/types.gen.ts
+++ b/web/src/lib/api/generated/types.gen.ts
@@ -2004,7 +2004,7 @@ export type SourceLocatorSchemaFlat = {
 	suffix?: string | null;
 	text_content?: string | null;
 	/**
-	 * Discriminator: "web_page_dom_range"
+	 * Discriminator: "web_page_dom_range" or "text_quote"
 	 */
 	type: string;
 	url?: string | null;

--- a/web/src/lib/components/reader/HighlightToolbar.svelte
+++ b/web/src/lib/components/reader/HighlightToolbar.svelte
@@ -3,7 +3,8 @@
 	import type { HighlightWithNoteResponse } from '$lib/api/generated/types.gen';
 	import * as apiSdk from '$lib/api';
 	import { fetchAllPages } from '$lib/api/pagination';
-	import { getSelectionOffsets, applyHighlights } from './highlight-utils';
+	import { getSelectionOffsets, applyHighlights, resolveHighlightRanges } from './highlight-utils';
+	import { t } from '$lib/i18n';
 	import HighlightFloatingToolbar from './HighlightFloatingToolbar.svelte';
 	import HighlightContextMenu from './HighlightContextMenu.svelte';
 	import HighlightTagPicker from './HighlightTagPicker.svelte';
@@ -11,7 +12,7 @@
 		filterTagSuggestions,
 		getPdfHighlightData,
 		getTagPickerPlacement,
-		getVisibleHighlightRanges,
+		getVisibleHighlightAnchors,
 		HIGHLIGHT_COLORS,
 		normalizeTagName
 	} from './highlight-toolbar-model';
@@ -43,29 +44,26 @@
 		}>;
 	};
 
+	interface HighlightCreateData {
+		text_content: string;
+		color: string;
+		start_offset: number;
+		end_offset: number;
+		chapter_id?: string;
+		source_locator?: { type: 'text_quote'; prefix?: string; suffix?: string };
+	}
+
 	interface Props {
 		highlights: HighlightWithNoteResponse[];
 		htmlContent?: string;
 		targetHighlightId?: string | null;
 		articleBodyEl?: HTMLElement | null;
-		onHighlightCreate?: (data: {
-			text_content: string;
-			color: string;
-			start_offset: number;
-			end_offset: number;
-			chapter_id?: string;
-		}) => void;
+		onHighlightCreate?: (data: HighlightCreateData) => void;
 		onPdfHighlightCreate?: (data: PdfHighlightCreateData) => void;
 		onHighlightDelete: (highlightId: string) => void;
 		onHighlightColorChange: (highlightId: string, color: string) => void;
 		onHighlightTagsChange?: (highlightId: string, tags: string[]) => void;
-		onHighlightCreateForTag?: (data: {
-			text_content: string;
-			color: string;
-			start_offset: number;
-			end_offset: number;
-			chapter_id?: string;
-		}) => Promise<string | null>;
+		onHighlightCreateForTag?: (data: HighlightCreateData) => Promise<string | null>;
 		epubChapterId?: string;
 		pdfPage?: number;
 		pdfScrollMode?: boolean;
@@ -90,6 +88,7 @@
 	}: Props = $props();
 
 	let showToolbar = $state(false);
+	let unplacedCount = $state(0);
 	let toolbarX = $state(0);
 	let toolbarY = $state(0);
 	let toolbarEl = $state<HTMLDivElement | undefined>(undefined);
@@ -118,6 +117,14 @@
 	let toolbarClientX = $state(0);
 	let toolbarClientY = $state(0);
 
+	function textQuote(offsets: {
+		prefix?: string;
+		suffix?: string;
+	}): HighlightCreateData['source_locator'] {
+		if (!offsets.prefix && !offsets.suffix) return undefined;
+		return { type: 'text_quote', prefix: offsets.prefix, suffix: offsets.suffix };
+	}
+
 	function getArticleBody(): HTMLElement | null {
 		return articleBodyEl ?? null;
 	}
@@ -145,7 +152,12 @@
 
 		if (!htmlContent) return;
 
-		applyHighlights(container, getVisibleHighlightRanges(highlights, locatorType, epubChapterId));
+		const resolved = resolveHighlightRanges(
+			container,
+			getVisibleHighlightAnchors(highlights, locatorType, epubChapterId)
+		);
+		unplacedCount = resolved.unplaced;
+		applyHighlights(container, resolved.ranges);
 		applyHighlightTagIndicators(container, highlights, HIGHLIGHT_COLORS);
 	}
 
@@ -239,13 +251,7 @@
 		const container = getArticleBody();
 		if (!container || !onHighlightCreateForTag) return;
 
-		let data: {
-			text_content: string;
-			color: string;
-			start_offset: number;
-			end_offset: number;
-			chapter_id?: string;
-		} | null = null;
+		let data: HighlightCreateData | null = null;
 
 		if (epubScrollMode) {
 			const chapterCtx = findEpubChapterFromSelection();
@@ -266,7 +272,8 @@
 				text_content: offsets.text,
 				color: HIGHLIGHT_COLORS[0]!.name,
 				start_offset: offsets.startOffset,
-				end_offset: offsets.endOffset
+				end_offset: offsets.endOffset,
+				source_locator: textQuote(offsets)
 			};
 		}
 
@@ -427,7 +434,8 @@
 				text_content: offsets.text,
 				color,
 				start_offset: offsets.startOffset,
-				end_offset: offsets.endOffset
+				end_offset: offsets.endOffset,
+				source_locator: textQuote(offsets)
 			});
 		}
 
@@ -539,6 +547,12 @@
 </script>
 
 <svelte:window onpointerup={handlePointerUp} onpointerdown={handlePointerDown} />
+
+{#if unplacedCount > 0}
+	<p class="highlight-unplaced-notice" role="status">
+		{$t('reader_highlights_unplaced', { values: { count: unplacedCount } })}
+	</p>
+{/if}
 
 {#if showToolbar}
 	<HighlightFloatingToolbar

--- a/web/src/lib/components/reader/highlight-toolbar-model.ts
+++ b/web/src/lib/components/reader/highlight-toolbar-model.ts
@@ -1,5 +1,6 @@
 import type { HighlightWithNoteResponse, TagResponse } from '$lib/api/generated/types.gen';
-import type { HighlightRange } from './highlight-utils';
+import type { HighlightAnchor } from './highlight-utils';
+import type { AnchorContext } from '../../../../../shared/highlight-source';
 import type { PdfHighlightData, PdfLocator } from './book/pdf/pdf-highlight-overlay';
 import type { MessageKey } from '$lib/i18n';
 
@@ -58,30 +59,41 @@ export function getPdfHighlightData(highlights: HighlightWithNoteResponse[]): Pd
 		}));
 }
 
-export function getVisibleHighlightRanges(
+export function getVisibleHighlightAnchors(
 	highlights: HighlightWithNoteResponse[],
 	locatorType: 'html' | 'epub',
 	epubChapterId?: string
-): HighlightRange[] {
+): HighlightAnchor[] {
 	return highlights
 		.filter((highlight) => highlight.color !== 'bookmark')
 		.filter((highlight) => {
-			if (!highlight.locator) return false;
 			if (locatorType === 'epub') {
-				return highlight.locator.type === 'epub' && highlight.locator.chapter === epubChapterId;
+				return highlight.locator?.type === 'epub' && highlight.locator.chapter === epubChapterId;
 			}
-			return highlight.locator.type === 'html';
+			return !highlight.locator || highlight.locator.type === 'html';
 		})
 		.map((highlight) => ({
 			id: highlight.id,
 			color: highlight.color,
-			startOffset:
+			text_content: highlight.text_content,
+			locator:
 				highlight.locator && 'start_offset' in highlight.locator
-					? (highlight.locator.start_offset ?? 0)
-					: 0,
-			endOffset:
-				highlight.locator && 'end_offset' in highlight.locator
-					? (highlight.locator.end_offset ?? 0)
-					: 0
+					? {
+							start_offset: highlight.locator.start_offset ?? 0,
+							end_offset: highlight.locator.end_offset ?? 0
+						}
+					: null,
+			context: anchorContext(highlight.source_locator)
 		}));
+}
+
+function anchorContext(
+	source: HighlightWithNoteResponse['source_locator']
+): AnchorContext | undefined {
+	if (!source) return undefined;
+	return {
+		offset: source.offset ?? undefined,
+		prefix: source.prefix ?? undefined,
+		suffix: source.suffix ?? undefined
+	};
 }

--- a/web/src/lib/components/reader/highlight-toolbar.css
+++ b/web/src/lib/components/reader/highlight-toolbar.css
@@ -49,3 +49,13 @@
 	flex-shrink: 0;
 	background: var(--border-secondary);
 }
+
+.highlight-unplaced-notice {
+	margin: 0 0 16px;
+	padding: 8px 12px;
+	border: 1px solid var(--border-secondary);
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	color: var(--text-secondary);
+	font-size: 13px;
+}

--- a/web/src/lib/components/reader/highlight-utils.test.ts
+++ b/web/src/lib/components/reader/highlight-utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getSelectionOffsets, resolveHighlightRanges } from './highlight-utils';
+
+function container(html: string): HTMLElement {
+	const el = document.createElement('div');
+	el.innerHTML = html;
+	document.body.appendChild(el);
+	return el;
+}
+
+describe('resolveHighlightRanges', () => {
+	it('keeps a locator whose text still matches', () => {
+		const el = container('<p>Hello brave world.</p>');
+		const { ranges, unplaced } = resolveHighlightRanges(el, [
+			{
+				id: 'h1',
+				color: 'yellow',
+				text_content: 'brave',
+				locator: { start_offset: 6, end_offset: 11 }
+			}
+		]);
+		expect(ranges[0]).toMatchObject({ id: 'h1', startOffset: 6, endOffset: 11 });
+		expect(unplaced).toBe(0);
+	});
+
+	it('falls back to text search when the locator is null', () => {
+		const el = container('<p>Later edited in a final form.<sup>40</sup> French theorist.</p>');
+		const { ranges } = resolveHighlightRanges(el, [
+			{ id: 'h2', color: 'yellow', text_content: 'edited in a final form.[35]', locator: null }
+		]);
+		const range = ranges[0]!;
+		expect(el.textContent!.slice(range.startOffset, range.endOffset)).toBe(
+			'edited in a final form.40'
+		);
+	});
+
+	it('falls back when the locator points at different text', () => {
+		const el = container('<p>Alpha target. Beta target.</p>');
+		const { ranges } = resolveHighlightRanges(el, [
+			{
+				id: 'h3',
+				color: 'yellow',
+				text_content: 'Beta target',
+				locator: { start_offset: 0, end_offset: 11 }
+			}
+		]);
+		expect(ranges[0]!.startOffset).toBe('Alpha target. '.length);
+	});
+
+	it('counts an unhinted repeat as unplaced and logs the stage', () => {
+		const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+		const el = container('<p>Alpha target. Beta target.</p>');
+		const result = resolveHighlightRanges(el, [
+			{ id: 'h4', color: 'yellow', text_content: 'target', locator: null }
+		]);
+		expect(result).toEqual({ ranges: [], unplaced: 1 });
+		expect(debug).toHaveBeenCalledWith('[reader] highlight not placed', {
+			id: 'h4',
+			stage: 'ambiguous'
+		});
+		debug.mockRestore();
+	});
+});
+
+describe('getSelectionOffsets', () => {
+	it('returns trimmed context around the selection', () => {
+		const el = container('<p>Before words. The quote here. After words.</p>');
+		const textNode = el.querySelector('p')!.firstChild as Text;
+		const start = el.textContent!.indexOf('The quote');
+		const range = document.createRange();
+		range.setStart(textNode, start);
+		range.setEnd(textNode, start + 'The quote here.'.length);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+
+		const offsets = getSelectionOffsets(el);
+
+		expect(offsets).toMatchObject({
+			text: 'The quote here.',
+			startOffset: start,
+			prefix: 'Before words.',
+			suffix: 'After words.'
+		});
+	});
+});

--- a/web/src/lib/components/reader/highlight-utils.ts
+++ b/web/src/lib/components/reader/highlight-utils.ts
@@ -1,9 +1,32 @@
-import { boundaryAt, buildTextIndex, type TextRun } from '../../../../../shared/highlight-source';
+import {
+	boundaryAt,
+	buildTextIndex,
+	resolveTextAnchor,
+	type AnchorContext,
+	type TextRun
+} from '../../../../../shared/highlight-source';
+
+const CONTEXT_CHARS = 80;
 
 export interface SelectionOffsets {
 	text: string;
 	startOffset: number;
 	endOffset: number;
+	prefix?: string;
+	suffix?: string;
+}
+
+export interface HighlightAnchor {
+	id: string;
+	color: string;
+	text_content: string;
+	locator?: { start_offset: number; end_offset: number } | null;
+	context?: AnchorContext;
+}
+
+export interface ResolvedHighlightRanges {
+	ranges: HighlightRange[];
+	unplaced: number;
 }
 
 /**
@@ -28,7 +51,48 @@ export function getSelectionOffsets(containerEl: HTMLElement): SelectionOffsets 
 
 	if (startOffset === -1 || endOffset === -1) return null;
 
-	return { text, startOffset, endOffset };
+	const pageText = buildTextIndex(containerEl, shouldIndexReaderTextNode).text;
+	const prefix = pageText.slice(Math.max(0, startOffset - CONTEXT_CHARS), startOffset).trim();
+	const suffix = pageText.slice(endOffset, endOffset + CONTEXT_CHARS).trim();
+	return {
+		text,
+		startOffset,
+		endOffset,
+		prefix: prefix || undefined,
+		suffix: suffix || undefined
+	};
+}
+
+export function resolveHighlightRanges(
+	containerEl: HTMLElement,
+	anchors: HighlightAnchor[]
+): ResolvedHighlightRanges {
+	const index = buildTextIndex(containerEl, shouldIndexReaderTextNode);
+	const ranges: HighlightRange[] = [];
+	let unplaced = 0;
+	for (const anchor of anchors) {
+		const locator = anchor.locator;
+		const resolution = resolveTextAnchor(index.text, {
+			text: anchor.text_content,
+			hint: locator ? { start: locator.start_offset, end: locator.end_offset } : undefined,
+			context: anchor.context
+		});
+		if (resolution.kind === 'placed') {
+			ranges.push({
+				id: anchor.id,
+				color: anchor.color,
+				startOffset: resolution.start,
+				endOffset: resolution.end
+			});
+			if (resolution.via === 'search') {
+				console.debug('[reader] highlight placed by search', { id: anchor.id });
+			}
+		} else {
+			unplaced += 1;
+			console.debug('[reader] highlight not placed', { id: anchor.id, stage: resolution.kind });
+		}
+	}
+	return { ranges, unplaced };
 }
 
 function shouldIndexReaderTextNode(node: Text): boolean {

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -1654,6 +1654,7 @@
 	"reader_hide_sidebar": "Hide sidebar",
 	"reader_highlight_color": "Highlight {color}",
 	"reader_highlights": "Highlights",
+	"reader_highlights_unplaced": "{count, plural, one {# highlight couldn't be placed in this text} other {# highlights couldn't be placed in this text}}",
 	"reader_hours_estimated": "{hours, plural, one {~# h estimated} other {~# h estimated}}",
 	"reader_isbn": "ISBN",
 	"reader_item_not_found": "Item not found.",

--- a/web/src/lib/i18n/locales/fr.json
+++ b/web/src/lib/i18n/locales/fr.json
@@ -1654,6 +1654,7 @@
 	"reader_hide_sidebar": "Masquer la barre latérale",
 	"reader_highlight_color": "Surligner en {color}",
 	"reader_highlights": "Passages surlignés",
+	"reader_highlights_unplaced": "{count, plural, one {# surlignage n'a pas pu être placé dans ce texte} other {# surlignages n'ont pas pu être placés dans ce texte}}",
 	"reader_hours_estimated": "{hours, plural, one {~# h estimée} other {~# h estimées}}",
 	"reader_isbn": "ISBN",
 	"reader_item_not_found": "Élément introuvable.",

--- a/web/src/routes/(app)/reader/[documentId]/+page.svelte
+++ b/web/src/routes/(app)/reader/[documentId]/+page.svelte
@@ -427,6 +427,7 @@
 		color: string;
 		start_offset: number;
 		end_offset: number;
+		source_locator?: { type: 'text_quote'; prefix?: string; suffix?: string };
 	}) {
 		try {
 			const { data: created } = await apiSdk.createHighlight({
@@ -438,7 +439,8 @@
 						type: 'html' as const,
 						start_offset: data.start_offset,
 						end_offset: data.end_offset
-					}
+					},
+					source_locator: data.source_locator
 				}
 			});
 			if (created) {
@@ -491,6 +493,7 @@
 		start_offset: number;
 		end_offset: number;
 		chapter_id?: string;
+		source_locator?: { type: 'text_quote'; prefix?: string; suffix?: string };
 	}): Promise<string | null> {
 		try {
 			const { data: created } = await apiSdk.createHighlight({
@@ -502,7 +505,8 @@
 						type: 'html' as const,
 						start_offset: data.start_offset,
 						end_offset: data.end_offset
-					}
+					},
+					source_locator: data.source_locator
 				}
 			});
 			if (created) {

--- a/web/src/routes/(app)/reader/[documentId]/components/ReaderMainPane.svelte
+++ b/web/src/routes/(app)/reader/[documentId]/components/ReaderMainPane.svelte
@@ -25,6 +25,7 @@
 		color: string;
 		start_offset: number;
 		end_offset: number;
+		source_locator?: { type: 'text_quote'; prefix?: string; suffix?: string };
 	};
 
 	interface Props {


### PR DESCRIPTION
- stored offsets verified against text_content; fallback to tolerant search; ambiguous placements refused
- create sends text_quote context (prefix/suffix)
- reader reports highlights that could not be placed
- depends on #30 and #31