### PR TITLE
fix(extension): harden selection capture and token refresh

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -792,17 +792,22 @@ async function buildReaderLocator(
   }
 }
 
-async function fetchReadableHtml(libraryEntryId: string): Promise<string | undefined> {
-  try {
-    const asset = await getEntryAsset(libraryEntryId, 'readable_html')
-    if (asset?.download_url) {
-      // download_url targets the API asset proxy, which requires auth.
-      const download = await authenticatedFetch(new URL(asset.download_url).pathname)
-      if (download.ok) return await download.text()
-    }
-  } catch {}
+// Saves return 202 and the worker produces the readable asset afterwards.
+const READABLE_ASSET_POLL = { attempts: 6, intervalMs: 1500 }
 
+async function fetchReadableHtml(libraryEntryId: string): Promise<string | undefined> {
+  for (let attempt = 0; attempt < READABLE_ASSET_POLL.attempts; attempt += 1) {
+    if (attempt > 0) await delay(READABLE_ASSET_POLL.intervalMs)
+    const asset = await getEntryAsset(libraryEntryId, 'readable_html')
+    if (asset?.status !== 'completed' || !asset.download_url) continue
+    const download = await authenticatedFetch(new URL(asset.download_url).pathname)
+    return download.ok ? await download.text() : undefined
+  }
   return undefined
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 async function setActionIdle(tabId: number): Promise<void> {

--- a/extension/entrypoints/full-archive.content.ts
+++ b/extension/entrypoints/full-archive.content.ts
@@ -11,7 +11,7 @@ import {
 import { classifyExtensionUrl } from '@/lib/content-type'
 import { extractReadableContent } from '@/lib/readable-extraction'
 import { beginCaptureDomCleanup } from '@/lib/dom-preprocessor'
-import { nodePath } from '@/lib/dom-range'
+import { captureSelection } from '@/lib/selection-capture'
 import { extractCoverUrl } from '@/lib/cover-image'
 import { renderToolbar } from '@/lib/full-archive-toolbar'
 import { escapeAttr, escapeHtml } from '@/lib/html'
@@ -57,7 +57,7 @@ export default defineContentScript({
             return true
           case 'selection:capture':
             try {
-              sendResponse(captureSelection())
+              sendResponse(captureSelection(document))
             } catch (err) {
               sendResponse(captureError(err))
             }
@@ -241,61 +241,6 @@ function extractCanonicalPageUrl(): string | undefined {
   if (canonical) return canonical
   const ogUrl = document.querySelector<HTMLMetaElement>('meta[property="og:url"][content]')?.content
   return ogUrl || undefined
-}
-
-function captureSelection(): CaptureMessage {
-  const selection = window.getSelection()
-  if (!selection || selection.rangeCount === 0 || selection.toString().trim().length === 0) {
-    return { action: 'capture:error', message: 'No selected text found' }
-  }
-
-  const range = selection.getRangeAt(0)
-  const text = selection.toString().trim()
-  const offset = flattenedTextOffset(range.startContainer, range.startOffset)
-  const location = `${nodePath(range.startContainer)}:${range.startOffset},${nodePath(
-    range.endContainer,
-  )}:${range.endOffset}`
-  const context = selectionContext(text, offset)
-
-  return {
-    action: 'selection:result',
-    payload: {
-      text,
-      sourceLocator: {
-        type: 'web_page_dom_range',
-        url: document.location.href,
-        location,
-        offset,
-        text_content: text,
-        prefix: context.prefix,
-        suffix: context.suffix,
-      },
-    },
-  }
-}
-
-function flattenedTextOffset(startNode: Node, startOffset: number): number {
-  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
-  let offset = 0
-  let node: Node | null = walker.nextNode()
-  while (node) {
-    if (node === startNode) return offset + startOffset
-    offset += node.textContent?.length ?? 0
-    node = walker.nextNode()
-  }
-  return offset
-}
-
-function selectionContext(text: string, offset: number): { prefix?: string; suffix?: string } {
-  const allText = document.body?.textContent ?? ''
-  const start = Math.max(0, offset - 80)
-  const end = Math.min(allText.length, offset + text.length + 80)
-  const prefix = allText.slice(start, offset).trim()
-  const suffix = allText.slice(offset + text.length, end).trim()
-  return {
-    prefix: prefix || undefined,
-    suffix: suffix || undefined,
-  }
 }
 
 function extractTweetContent(): {

--- a/extension/lib/api.ts
+++ b/extension/lib/api.ts
@@ -132,7 +132,16 @@ export async function authenticatedFetch(path: string, init?: RequestInit): Prom
   return response
 }
 
-export async function refreshAccessToken(): Promise<boolean> {
+let refreshInFlight: Promise<boolean> | null = null
+
+export function refreshAccessToken(): Promise<boolean> {
+  refreshInFlight ??= refreshAccessTokenOnce().finally(() => {
+    refreshInFlight = null
+  })
+  return refreshInFlight
+}
+
+async function refreshAccessTokenOnce(): Promise<boolean> {
   const refreshToken = await getRefreshToken()
   if (!refreshToken) return false
 

--- a/extension/lib/selection-capture.ts
+++ b/extension/lib/selection-capture.ts
@@ -1,0 +1,56 @@
+import { boundaryAt, buildTextIndex } from '../../shared/highlight-source'
+import type { CaptureMessage } from './capture'
+import { nodePath } from './dom-range'
+import { clearProjectedHighlights } from './highlight-projection'
+import { isPageTextNode, rangeToOffsets } from './page-text'
+
+const CONTEXT_CHARS = 80
+
+/** Clears projected marks so the location describes the page as first loaded. */
+export function captureSelection(doc: Document): CaptureMessage {
+  const selection = doc.getSelection()
+  if (!selection || selection.rangeCount === 0 || selection.toString().trim().length === 0) {
+    return { action: 'capture:error', message: 'No selected text found' }
+  }
+
+  const range = selection.getRangeAt(0)
+  const raw = selection.toString()
+  const text = raw.trim()
+  const live = buildTextIndex(doc.body, isPageTextNode)
+  const rawOffsets = rangeToOffsets(live, range)
+  if (!rawOffsets) {
+    return { action: 'capture:error', message: 'No selected text found' }
+  }
+  const start = rawOffsets.start + (raw.length - raw.trimStart().length)
+  const end = rawOffsets.end - (raw.length - raw.trimEnd().length)
+
+  clearProjectedHighlights(doc)
+  const pristine = buildTextIndex(doc.body, isPageTextNode)
+  const startBoundary = boundaryAt(pristine.runs, start, false)
+  const endBoundary = boundaryAt(pristine.runs, end, true)
+  if (!startBoundary || !endBoundary) {
+    return { action: 'capture:error', message: 'No selected text found' }
+  }
+
+  const location = `${nodePath(startBoundary.node)}:${startBoundary.offset},${nodePath(
+    endBoundary.node,
+  )}:${endBoundary.offset}`
+  const prefix = pristine.text.slice(Math.max(0, start - CONTEXT_CHARS), start).trim()
+  const suffix = pristine.text.slice(end, end + CONTEXT_CHARS).trim()
+
+  return {
+    action: 'selection:result',
+    payload: {
+      text,
+      sourceLocator: {
+        type: 'web_page_dom_range',
+        url: doc.location.href,
+        location,
+        offset: start,
+        text_content: text,
+        prefix: prefix || undefined,
+        suffix: suffix || undefined,
+      },
+    },
+  }
+}

--- a/extension/tests/api.test.ts
+++ b/extension/tests/api.test.ts
@@ -527,3 +527,34 @@ describe('api', () => {
     })
   })
 })
+
+describe('refreshAccessToken', () => {
+  beforeEach(() => {
+    clearMockStorage()
+    clearAccessTokenMemory()
+    fetchMock.mockReset()
+  })
+
+  it('shares one refresh request between concurrent callers', async () => {
+    mockStorage['ind_refresh_token'] = 'refresh_1'
+    mockStorage['ind_server_url'] = 'https://test.useindelible.com'
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'jwt_2',
+            refresh_token: 'refresh_2',
+            expires_at: FUTURE_EXPIRY,
+            token_type: 'Bearer',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    )
+
+    const results = await Promise.all([refreshAccessToken(), refreshAccessToken()])
+
+    expect(results).toEqual([true, true])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mockStorage['ind_refresh_token']).toBe('refresh_2')
+  })
+})

--- a/extension/tests/background.test.ts
+++ b/extension/tests/background.test.ts
@@ -667,13 +667,21 @@ describe('background message handler', () => {
         return new Response('unexpected request', { status: 500 })
       })
 
-      await sendMessage({ action: 'toolbar:highlight-selection' }, { id: EXTENSION_ID })
+      vi.useFakeTimers()
+      try {
+        const pending = sendMessage({ action: 'toolbar:highlight-selection' }, { id: EXTENSION_ID })
+        await vi.advanceTimersByTimeAsync(1500 * 6)
+        await pending
+      } finally {
+        vi.useRealTimers()
+      }
 
       expect(checkedUrl).toBe('https://new-indelible.example.com/library')
       expect(highlightWriteAttempted).toBe(false)
     })
 
-    async function highlightThroughReaderLocator(locatorFails: boolean) {
+    async function highlightThroughReaderLocator(locatorFails: boolean, pendingAssetPolls = 0) {
+      let assetPolls = 0
       const libraryEntryId = 'lib_018f2f1a-1111-7222-8333-111111111111'
       const tab = {
         id: 42,
@@ -736,8 +744,16 @@ describe('background message handler', () => {
         }
 
         if (href.endsWith(`/api/v1/extension/entries/${libraryEntryId}/assets/readable_html`)) {
+          assetPolls += 1
+          if (assetPolls <= pendingAssetPolls) {
+            return new Response(JSON.stringify({ status: 'processing' }), {
+              status: 200,
+              headers: jsonHeaders,
+            })
+          }
           return new Response(
             JSON.stringify({
+              status: 'completed',
               download_url:
                 'https://test.useindelible.com/api/v1/assets/documents/doc_018f2f1a-1111-7222-8333-222222222222/readable_html',
             }),
@@ -797,12 +813,31 @@ describe('background message handler', () => {
         return new Response('unexpected request', { status: 500 })
       })
 
-      const response = await sendMessage(
-        { action: 'toolbar:highlight-selection' },
-        { id: EXTENSION_ID },
-      )
-      return { response, highlightBody, locatorRequest, libraryEntryId }
+      const pending = sendMessage({ action: 'toolbar:highlight-selection' }, { id: EXTENSION_ID })
+      for (let i = 0; i < pendingAssetPolls; i += 1) {
+        await vi.advanceTimersByTimeAsync(1500)
+      }
+      const response = await pending
+      return { response, highlightBody, locatorRequest, libraryEntryId, assetPolls }
     }
+
+    it('waits for the readable asset to complete after a fresh save', async () => {
+      vi.useFakeTimers()
+      try {
+        const { response, highlightBody, assetPolls } = await highlightThroughReaderLocator(
+          false,
+          2,
+        )
+
+        expect(response.success).toBe(true)
+        expect(assetPolls).toBe(3)
+        expect(highlightBody).toMatchObject({
+          locator: { type: 'html', start_offset: 7, end_offset: 22 },
+        })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
 
     it('asks the content script for a reader locator built from the readable asset', async () => {
       const { response, highlightBody, locatorRequest, libraryEntryId } =

--- a/extension/tests/selection-capture.test.ts
+++ b/extension/tests/selection-capture.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { projectHighlights } from '../lib/highlight-projection'
+import { captureSelection } from '../lib/selection-capture'
+
+function select(node: Text, start: number, end: number): void {
+  const range = document.createRange()
+  range.setStart(node, start)
+  range.setEnd(node, end)
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+function lastTextNode(el: Element): Text {
+  return el.lastChild as Text
+}
+
+describe('captureSelection', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    window.getSelection()?.removeAllRanges()
+  })
+
+  it('describes the location on the unprojected page even when marks are present', () => {
+    document.body.innerHTML = '<p>Hello brave world.</p>'
+    const p = document.querySelector('p')!
+    const textNode = p.firstChild as Text
+    select(textNode, 12, 17)
+    const pristine = captureSelection(document)
+
+    document.body.innerHTML = '<p>Hello brave world.</p>'
+    projectHighlights([{ id: 'h', text_content: 'brave' }], document)
+    const worldNode = lastTextNode(document.querySelector('p')!)
+    select(worldNode, worldNode.data.indexOf('world'), worldNode.data.indexOf('world') + 5)
+    const projected = captureSelection(document)
+
+    expect(projected.action).toBe('selection:result')
+    if (pristine.action !== 'selection:result' || projected.action !== 'selection:result') return
+    expect(projected.payload.sourceLocator.location).toBe(pristine.payload.sourceLocator.location)
+    expect(projected.payload.sourceLocator.offset).toBe(12)
+    expect(document.querySelector('mark')).toBeNull()
+  })
+
+  it('ignores script text for offsets and context', () => {
+    document.body.innerHTML = '<script>var x = "zzzz";</script><p>Alpha beta.</p>'
+    const textNode = document.querySelector('p')!.firstChild as Text
+    select(textNode, 6, 10)
+
+    const result = captureSelection(document)
+
+    expect(result.action).toBe('selection:result')
+    if (result.action !== 'selection:result') return
+    expect(result.payload.sourceLocator.offset).toBe(6)
+    expect(result.payload.sourceLocator.prefix).toBe('Alpha')
+    expect(result.payload.sourceLocator.suffix).toBe('.')
+  })
+
+  it('trims surrounding whitespace out of the text and offsets', () => {
+    document.body.innerHTML = '<p>one  two three</p>'
+    const textNode = document.querySelector('p')!.firstChild as Text
+    select(textNode, 3, 9)
+
+    const result = captureSelection(document)
+
+    expect(result.action).toBe('selection:result')
+    if (result.action !== 'selection:result') return
+    expect(result.payload.text).toBe('two')
+    expect(result.payload.sourceLocator.offset).toBe(5)
+    expect(result.payload.sourceLocator.location).toBe('1/0/0:5,1/0/0:8')
+  })
+})


### PR DESCRIPTION
- wait for the readable asset to complete before anchoring a fresh save
- capture selections against the unprojected page with the shared text index
- share one in-flight token refresh