### PR TITLE
fix(extension): localize remaining toolbar and badge copy

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -245,7 +245,7 @@ async function handleAuthStart(
   try {
     const serverUrl = typeof message.serverUrl === 'string' ? message.serverUrl : ''
     if (!serverUrl) {
-      return { success: false, error: 'Server URL is required' }
+      return { success: false, error: t('error_server_url_required') }
     }
     const result = await connect(serverUrl, returnTabId)
     if (result.returnTabId) {
@@ -299,14 +299,17 @@ async function handleSetServerUrl(
 ): Promise<{ success: boolean; error?: string }> {
   const serverUrl = typeof message.serverUrl === 'string' ? message.serverUrl : ''
   if (!serverUrl) {
-    return { success: false, error: 'Server URL is required' }
+    return { success: false, error: t('error_server_url_required') }
   }
 
   try {
     await setServerUrl(serverUrl)
     return { success: true }
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : 'Server URL is invalid' }
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : t('error_server_url_invalid'),
+    }
   }
 }
 
@@ -362,7 +365,7 @@ async function handleActionClick(tab: Browser.tabs.Tab): Promise<void> {
       view: 'saving',
       serverUrl: auth.serverUrl,
       url: tab.url,
-      step: 'Saving…',
+      step: 'extracting',
     })
     return
   }
@@ -385,7 +388,7 @@ async function handleActionClick(tab: Browser.tabs.Tab): Promise<void> {
 
 async function handleToolbarSave(): Promise<{ success: boolean; error?: string }> {
   const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
-  if (!tab?.id) return { success: false, error: 'No active tab found' }
+  if (!tab?.id) return { success: false, error: t('error_no_active_tab') }
   const result = await handleCaptureStart(tab)
   if (result.success && result.data?.libraryEntryId) {
     await loadToolbarPanel(tab.id, await getServerUrl(), result.data.libraryEntryId)
@@ -399,12 +402,12 @@ async function handleToolbarHighlightSelection(
   const [tab] = sourceTab?.id
     ? [sourceTab]
     : await browser.tabs.query({ active: true, currentWindow: true })
-  if (!tab?.id) return { success: false, error: 'No active tab found' }
+  if (!tab?.id) return { success: false, error: t('error_no_active_tab') }
   try {
     await handleSelectionHighlight(tab)
     return { success: true }
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Highlight failed'
+    const message = err instanceof Error ? err.message : t('error_highlight')
     await setActionError(tab.id, message)
     return { success: false, error: message }
   }
@@ -464,7 +467,7 @@ async function loadToolbarPanel(
     await renderToolbar(tabId, {
       view: 'error',
       serverUrl,
-      message: 'Saved entry was not found',
+      message: t('error_entry_not_found'),
     })
     return
   }
@@ -526,12 +529,12 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
     : await browser.tabs.query({ active: true, currentWindow: true })
   const tab = activeTab
   if (!tab?.id || !tab.url || !tab.title) {
-    return { success: false, error: 'No active tab found' }
+    return { success: false, error: t('error_no_active_tab') }
   }
   const serverUrl = await getServerUrl()
   if (!canExtensionSaveUrl(tab.url, serverUrl)) {
     await setActionIdle(tab.id)
-    return { success: false, error: 'This page cannot be saved' }
+    return { success: false, error: t('error_cannot_save') }
   }
 
   const tabId = tab.id
@@ -551,7 +554,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
       action: 'capture:run',
     } satisfies CaptureMessage)) as CaptureMessage
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Content script failed'
+    const message = err instanceof Error ? err.message : t('error_content_script')
     await setActionError(tabId, message)
     await renderToolbar(tabId, { view: 'error', serverUrl, message })
     return { success: false, error: message }
@@ -571,7 +574,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
           serverUrl: fallbackServerUrl,
           url: captureResult.payload.url,
         })
-        return { success: false, error: 'This page cannot be saved' }
+        return { success: false, error: t('error_cannot_save') }
       }
       try {
         const body = buildReaderSaveFallbackBody(
@@ -596,7 +599,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
           },
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Reader save failed'
+        const message = err instanceof Error ? err.message : t('error_reader_save')
         await setActionError(tabId, message)
         await renderToolbar(tabId, { view: 'error', serverUrl, message })
         return { success: false, error: message }
@@ -608,13 +611,13 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
   }
 
   if (captureResult.action !== 'capture:result') {
-    await setActionError(tabId, 'Unexpected response from content script')
+    await setActionError(tabId, t('error_unexpected_response'))
     await renderToolbar(tabId, {
       view: 'error',
       serverUrl,
-      message: 'Unexpected response from content script',
+      message: t('error_unexpected_response'),
     })
-    return { success: false, error: 'Unexpected response from content script' }
+    return { success: false, error: t('error_unexpected_response') }
   }
 
   const payload: CapturePayload = captureResult.payload
@@ -626,7 +629,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
       serverUrl: uploadServerUrl,
       url: payload.url,
     })
-    return { success: false, error: 'This page cannot be saved' }
+    return { success: false, error: t('error_cannot_save') }
   }
 
   setActionSaving(tabId, 'uploading')
@@ -671,7 +674,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
         serverUrl: fallbackServerUrl,
         url: payload.url,
       })
-      return { success: false, error: 'This page cannot be saved' }
+      return { success: false, error: t('error_cannot_save') }
     }
     try {
       const fallback = buildReaderSaveFallbackBody(
@@ -696,7 +699,7 @@ async function handleCaptureStart(sourceTab?: Browser.tabs.Tab): Promise<{
         },
       }
     } catch {
-      const message = err instanceof Error ? err.message : 'Upload failed'
+      const message = err instanceof Error ? err.message : t('error_upload')
       await setActionError(tabId, message)
       await renderToolbar(tabId, { view: 'error', serverUrl, message })
       return { success: false, error: message }
@@ -724,9 +727,7 @@ async function handleSelectionHighlight(tab?: Browser.tabs.Tab): Promise<void> {
 
   if (selectionResult.action !== 'selection:result') {
     const message =
-      selectionResult.action === 'capture:error'
-        ? selectionResult.message
-        : 'No selected text found'
+      selectionResult.action === 'capture:error' ? selectionResult.message : t('error_no_selection')
     await setActionError(activeTab.id, message)
     return
   }
@@ -743,7 +744,7 @@ async function handleSelectionHighlight(tab?: Browser.tabs.Tab): Promise<void> {
     libraryEntryId = saved.data?.libraryEntryId
   }
   if (!libraryEntryId) {
-    await setActionError(activeTab.id, 'Save the page before creating a highlight')
+    await setActionError(activeTab.id, t('error_save_before_highlight'))
     return
   }
 

--- a/extension/lib/full-archive-toolbar-markup.ts
+++ b/extension/lib/full-archive-toolbar-markup.ts
@@ -43,34 +43,34 @@ export function toolbarMarkup(state: ToolbarState): string {
 
   const tagChipsHtml = (state.tags ?? [])
     .map(
-      (t) =>
-        `<span class="tag-chip" data-tag="${escapeAttr(t)}">${escapeHtml(t)}<button class="tag-remove" title="Remove">×</button></span>`,
+      (tag) =>
+        `<span class="tag-chip" data-tag="${escapeAttr(tag)}">${escapeHtml(tag)}<button class="tag-remove" title="${escapeAttr(t('tag_remove'))}">×</button></span>`,
     )
     .join('')
 
   const tagPanel = `
     <div class="trs-panel tag-panel" style="display:none">
       <div class="panel-header">
-        <span class="panel-title">Tags</span>
-        <button class="ic-btn js-panel-close" title="Close">${IC_CLOSE}</button>
+        <span class="panel-title">${escapeHtml(t('tags_title'))}</span>
+        <button class="ic-btn js-panel-close" title="${escapeAttr(t('close'))}">${IC_CLOSE}</button>
       </div>
       <div class="tag-chips">${tagChipsHtml}</div>
       <div class="tag-input-wrap">
-        <input type="text" class="tag-input" placeholder="Add tag…">
-        <button class="btn-primary js-add-tag">Add</button>
+        <input type="text" class="tag-input" placeholder="${escapeAttr(t('tag_placeholder'))}">
+        <button class="btn-primary js-add-tag">${escapeHtml(t('add'))}</button>
       </div>
     </div>`
 
   const notePanel = `
     <div class="trs-panel note-panel" style="display:none">
       <div class="panel-header">
-        <span class="panel-title">Note</span>
-        <button class="ic-btn js-panel-close" title="Close">${IC_CLOSE}</button>
+        <span class="panel-title">${escapeHtml(t('note_title'))}</span>
+        <button class="ic-btn js-panel-close" title="${escapeAttr(t('close'))}">${IC_CLOSE}</button>
       </div>
-      <textarea class="note-textarea" placeholder="Add a note about this article…">${escapeHtml(state.note ?? '')}</textarea>
+      <textarea class="note-textarea" placeholder="${escapeAttr(t('note_placeholder'))}">${escapeHtml(state.note ?? '')}</textarea>
       <div class="note-actions">
-        <button class="btn-ghost js-cancel-note">Cancel</button>
-        <button class="btn-primary js-save-note">Save note</button>
+        <button class="btn-ghost js-cancel-note">${escapeHtml(t('cancel'))}</button>
+        <button class="btn-primary js-save-note">${escapeHtml(t('save_note'))}</button>
       </div>
     </div>`
 
@@ -88,46 +88,46 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <a class="btn-text" href="${readerUrl}" target="_blank" rel="noopener noreferrer">Open reader${IC_ARROW_RIGHT}</a>
+          <a class="btn-text" href="${readerUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(t('open_reader'))}${IC_ARROW_RIGHT}</a>
           ${highlightCount > 0 ? `<span class="count-pill">${escapeHtml(tPlural('toolbar_highlights', highlightCount))}</span>` : ''}
           <span class="count-pill js-unplaced" hidden></span>
         </div>
         <div class="item">
-          <span class="t">${escapeHtml(entry?.title ?? 'Saved page')}</span>
+          <span class="t">${escapeHtml(entry?.title ?? t('saved_page'))}</span>
           ${domainMeta ? `<span class="dot">·</span><span class="s">${escapeHtml(domainMeta)}</span>` : ''}
         </div>
         <div class="group">
           <div class="toggle-group">
             <span class="switch js-toggle off"><span class="knob"></span></span>
-            <span>Auto-highlight</span>
+            <span>${escapeHtml(t('auto_highlight'))}</span>
           </div>
           <span class="vr"></span>
-          <button class="ic-btn js-tag-btn" title="Tags">${IC_TAG}</button>
-          <button class="ic-btn js-note-btn" title="Note">${IC_NOTE}</button>
-          <button class="ic-btn js-star-btn${entry?.is_favorite ? ' starred' : ''}" title="Star">${IC_STAR}</button>
-          ${entry?.document_id ? `<button class="ic-btn js-reprocess-btn" title="Retry processing" aria-label="Retry processing">${IC_REFRESH}</button><span class="status js-reprocess-status" aria-live="polite"></span>` : ''}
+          <button class="ic-btn js-tag-btn" title="${escapeAttr(t('tags_title'))}">${IC_TAG}</button>
+          <button class="ic-btn js-note-btn" title="${escapeAttr(t('note_title'))}">${IC_NOTE}</button>
+          <button class="ic-btn js-star-btn${entry?.is_favorite ? ' starred' : ''}" title="${escapeAttr(t('star'))}">${IC_STAR}</button>
+          ${entry?.document_id ? `<button class="ic-btn js-reprocess-btn" title="${escapeAttr(t('retry_processing'))}" aria-label="${escapeAttr(t('retry_processing'))}">${IC_REFRESH}</button><span class="status js-reprocess-status" aria-live="polite"></span>` : ''}
           <span class="vr"></span>
           <button class="dropdown js-triage">
             <span class="triage-ic">${triageIcon(triage)}</span>
             <span class="triage-label">${escapeHtml(triageLabel(triage))}</span>
             ${IC_CHEVRON_DOWN}
           </button>
-          <button class="ic-btn js-minimize" title="Minimize">${IC_CHEVRON_UP}</button>
+          <button class="ic-btn js-minimize" title="${escapeAttr(t('minimize'))}">${IC_CHEVRON_UP}</button>
         </div>`
-      return `<div class="bar" role="region" aria-label="Indelible controls">${barContent}</div>${tagPanel}${notePanel}${triageMenu}`
+      return `<div class="bar" role="region" aria-label="${escapeAttr(t('controls_label'))}">${barContent}</div>${tagPanel}${notePanel}${triageMenu}`
 
     case 'saving':
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Saving this page</span>
+          <span class="item-name">${escapeHtml(t('saving_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">Extracting readable content and creating the archive</span>
+          <span class="s">${escapeHtml(t('saving_detail'))}</span>
         </div>
         <div class="group">
-          <span class="status saving"><span class="spinner"></span>Saving</span>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <span class="status saving"><span class="spinner"></span>${escapeHtml(t('saving_status'))}</span>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -135,14 +135,14 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Checking this page</span>
+          <span class="item-name">${escapeHtml(t('checking_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">Looking for an existing saved item after your click</span>
+          <span class="s">${escapeHtml(t('checking_detail'))}</span>
         </div>
         <div class="group">
-          <span class="status checking"><span class="spinner"></span>Checking</span>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <span class="status checking"><span class="spinner"></span>${escapeHtml(t('checking_status'))}</span>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -150,15 +150,15 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Connect Indelible</span>
+          <span class="item-name">${escapeHtml(t('connect_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">Authenticate your workspace before saving this page</span>
+          <span class="s">${escapeHtml(t('connect_detail'))}</span>
         </div>
         <div class="group">
           <input class="url-input" data-role="server-url" type="text" value="${escapeAttr(state.serverUrl ?? 'https://useindelible.com')}" placeholder="https://useindelible.com" spellcheck="false" autocomplete="off">
-          <button class="btn-primary" data-action="connect">Connect</button>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="btn-primary" data-action="connect">${escapeHtml(t('connect'))}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -166,16 +166,16 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Indelible is unreachable</span>
+          <span class="item-name">${escapeHtml(t('unreachable_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">${escapeHtml(state.message ?? 'Your session is retained · update the address if your server moved')}</span>
+          <span class="s">${escapeHtml(state.message ?? t('unreachable_detail'))}</span>
         </div>
         <div class="group">
           <input class="url-input" data-role="server-url" type="text" value="${escapeAttr(state.serverUrl ?? 'https://useindelible.com')}" placeholder="https://useindelible.com" spellcheck="false" autocomplete="off">
-          <button class="btn-primary" data-action="retry">Retry</button>
-          <button class="btn-ghost" data-action="sign-out">Sign out</button>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="btn-primary" data-action="retry">${escapeHtml(t('retry'))}</button>
+          <button class="btn-ghost" data-action="sign-out">${escapeHtml(t('sign_out'))}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -183,14 +183,14 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Connecting Indelible</span>
+          <span class="item-name">${escapeHtml(t('connecting_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">Opening secure browser authorization</span>
+          <span class="s">${escapeHtml(t('connecting_detail'))}</span>
         </div>
         <div class="group">
-          <span class="status checking"><span class="spinner"></span>Connecting</span>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <span class="status checking"><span class="spinner"></span>${escapeHtml(t('connecting_status'))}</span>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -198,14 +198,14 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Couldn’t connect</span>
+          <span class="item-name">${escapeHtml(t('auth_error_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">${escapeHtml(state.message ?? 'Authorization could not be started. Please try again.')}</span>
+          <span class="s">${escapeHtml(state.message ?? t('auth_error_detail'))}</span>
         </div>
         <div class="group">
-          <button class="btn-primary" data-action="connect">Try again</button>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="btn-primary" data-action="connect">${escapeHtml(t('try_again'))}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -213,14 +213,14 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Already in your library</span>
+          <span class="item-name">${escapeHtml(t('already_saved_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">This page was saved before — refresh to update or create a new entry</span>
+          <span class="s">${escapeHtml(t('already_saved_detail'))}</span>
         </div>
         <div class="group">
-          <button class="btn-ghost" data-action="refresh">Refresh</button>
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="btn-ghost" data-action="refresh">${escapeHtml(t('refresh'))}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -228,13 +228,13 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Can't save this page</span>
+          <span class="item-name">${escapeHtml(t('unsupported_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">This type of page cannot be archived</span>
+          <span class="s">${escapeHtml(t('unsupported_detail'))}</span>
         </div>
         <div class="group">
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
 
@@ -242,18 +242,18 @@ export function toolbarMarkup(state: ToolbarState): string {
       barContent = `
         <div class="left-lockup">
           ${BRAND_MARK}
-          <span class="item-name">Something went wrong</span>
+          <span class="item-name">${escapeHtml(t('error_title'))}</span>
         </div>
         <div class="item">
-          <span class="s">${escapeHtml(state.message ?? 'An error occurred while saving')}</span>
+          <span class="s">${escapeHtml(state.message ?? t('error_detail'))}</span>
         </div>
         <div class="group">
-          <button class="ic-btn js-dismiss" title="Dismiss">${IC_CLOSE}</button>
+          <button class="ic-btn js-dismiss" title="${escapeAttr(t('dismiss'))}">${IC_CLOSE}</button>
         </div>`
       break
   }
 
-  return `<div class="bar" role="region" aria-label="Indelible controls">${barContent}</div>`
+  return `<div class="bar" role="region" aria-label="${escapeAttr(t('controls_label'))}">${barContent}</div>`
 }
 
 function domainFromUrl(url: string | undefined): string | undefined {

--- a/extension/lib/full-archive-toolbar.ts
+++ b/extension/lib/full-archive-toolbar.ts
@@ -1,5 +1,5 @@
 import { escapeHtml } from '@/lib/html'
-import { tPlural } from '@/lib/i18n'
+import { t, tPlural } from '@/lib/i18n'
 import { nodePath } from '@/lib/dom-range'
 import {
   clearProjectedHighlights,
@@ -285,7 +285,7 @@ function bindToolbarEvents(root: ShadowRoot, state: ToolbarState): void {
       const status = root.querySelector<HTMLElement>('.js-reprocess-status')
       if (!documentId || !button || !status || button.disabled) return
       button.disabled = true
-      status.textContent = 'Queuing'
+      status.textContent = t('reprocess_queuing')
       try {
         const response = (await browser.runtime.sendMessage({
           action: 'toolbar:reprocess-document',
@@ -294,16 +294,16 @@ function bindToolbarEvents(root: ShadowRoot, state: ToolbarState): void {
         const record = isRecord(response) ? response : undefined
         const data = record && isRecord(record.data) ? record.data : undefined
         if (!record || record.success !== true || !data) {
-          throw new Error(typeof record?.error === 'string' ? record.error : 'Retry failed')
+          throw new Error(typeof record?.error === 'string' ? record.error : t('reprocess_failed'))
         }
         const queued = data.queued === true
         const retryAfter =
           typeof data.retry_after_seconds === 'number' ? data.retry_after_seconds : 0
         status.textContent = queued
-          ? 'Queued'
+          ? t('reprocess_queued')
           : retryAfter > 0
-            ? `Retry in ${retryAfter}s`
-            : 'Running'
+            ? t('reprocess_retry_in', String(retryAfter))
+            : t('reprocess_running')
         window.setTimeout(
           () => {
             button.disabled = false
@@ -313,7 +313,7 @@ function bindToolbarEvents(root: ShadowRoot, state: ToolbarState): void {
         )
       } catch (error) {
         button.disabled = false
-        status.textContent = error instanceof Error ? error.message : 'Retry failed'
+        status.textContent = error instanceof Error ? error.message : t('reprocess_failed')
       }
     })
 

--- a/extension/lib/selection-capture.ts
+++ b/extension/lib/selection-capture.ts
@@ -1,6 +1,7 @@
 import { boundaryAt, buildTextIndex } from '../../shared/highlight-source'
 import type { CaptureMessage } from './capture'
 import { nodePath } from './dom-range'
+import { t } from './i18n'
 import { clearProjectedHighlights } from './highlight-projection'
 import { isPageTextNode, rangeToOffsets } from './page-text'
 
@@ -10,7 +11,7 @@ const CONTEXT_CHARS = 80
 export function captureSelection(doc: Document): CaptureMessage {
   const selection = doc.getSelection()
   if (!selection || selection.rangeCount === 0 || selection.toString().trim().length === 0) {
-    return { action: 'capture:error', message: 'No selected text found' }
+    return { action: 'capture:error', message: t('error_no_selection') }
   }
 
   const range = selection.getRangeAt(0)
@@ -19,7 +20,7 @@ export function captureSelection(doc: Document): CaptureMessage {
   const live = buildTextIndex(doc.body, isPageTextNode)
   const rawOffsets = rangeToOffsets(live, range)
   if (!rawOffsets) {
-    return { action: 'capture:error', message: 'No selected text found' }
+    return { action: 'capture:error', message: t('error_no_selection') }
   }
   const start = rawOffsets.start + (raw.length - raw.trimStart().length)
   const end = rawOffsets.end - (raw.length - raw.trimEnd().length)
@@ -29,7 +30,7 @@ export function captureSelection(doc: Document): CaptureMessage {
   const startBoundary = boundaryAt(pristine.runs, start, false)
   const endBoundary = boundaryAt(pristine.runs, end, true)
   if (!startBoundary || !endBoundary) {
-    return { action: 'capture:error', message: 'No selected text found' }
+    return { action: 'capture:error', message: t('error_no_selection') }
   }
 
   const location = `${nodePath(startBoundary.node)}:${startBoundary.offset},${nodePath(

--- a/extension/public/_locales/en/messages.json
+++ b/extension/public/_locales/en/messages.json
@@ -2,8 +2,107 @@
   "action_title": {
     "message": "Indelible"
   },
+  "add": {
+    "message": "Add"
+  },
+  "already_saved_detail": {
+    "message": "This page was saved before — refresh to update or create a new entry"
+  },
+  "already_saved_title": {
+    "message": "Already in your library"
+  },
+  "auth_error_detail": {
+    "message": "Authorization could not be started. Please try again."
+  },
+  "auth_error_title": {
+    "message": "Couldn’t connect"
+  },
+  "auto_highlight": {
+    "message": "Auto-highlight"
+  },
+  "cancel": {
+    "message": "Cancel"
+  },
+  "checking_detail": {
+    "message": "Looking for an existing saved item after your click"
+  },
+  "checking_status": {
+    "message": "Checking"
+  },
+  "checking_title": {
+    "message": "Checking this page"
+  },
+  "close": {
+    "message": "Close"
+  },
   "command_save_page": {
     "message": "Save current page to Indelible"
+  },
+  "connect": {
+    "message": "Connect"
+  },
+  "connect_detail": {
+    "message": "Authenticate your workspace before saving this page"
+  },
+  "connect_title": {
+    "message": "Connect Indelible"
+  },
+  "connecting_detail": {
+    "message": "Opening secure browser authorization"
+  },
+  "connecting_status": {
+    "message": "Connecting"
+  },
+  "connecting_title": {
+    "message": "Connecting Indelible"
+  },
+  "controls_label": {
+    "message": "Indelible controls"
+  },
+  "dismiss": {
+    "message": "Dismiss"
+  },
+  "error_cannot_save": {
+    "message": "This page cannot be saved"
+  },
+  "error_content_script": {
+    "message": "Content script failed"
+  },
+  "error_detail": {
+    "message": "An error occurred while saving"
+  },
+  "error_entry_not_found": {
+    "message": "Saved entry was not found"
+  },
+  "error_highlight": {
+    "message": "Highlight failed"
+  },
+  "error_no_active_tab": {
+    "message": "No active tab found"
+  },
+  "error_no_selection": {
+    "message": "No selected text found"
+  },
+  "error_reader_save": {
+    "message": "Reader save failed"
+  },
+  "error_save_before_highlight": {
+    "message": "Save the page before creating a highlight"
+  },
+  "error_server_url_invalid": {
+    "message": "Server URL is invalid"
+  },
+  "error_server_url_required": {
+    "message": "Server URL is required"
+  },
+  "error_title": {
+    "message": "Something went wrong"
+  },
+  "error_unexpected_response": {
+    "message": "Unexpected response from content script"
+  },
+  "error_upload": {
+    "message": "Upload failed"
   },
   "ext_description": {
     "message": "Save, archive, and organize web content with Indelible"
@@ -16,6 +115,15 @@
   },
   "menu_save_page": {
     "message": "Save to Indelible"
+  },
+  "minimize": {
+    "message": "Minimize"
+  },
+  "note_placeholder": {
+    "message": "Add a note about this article…"
+  },
+  "note_title": {
+    "message": "Note"
   },
   "notify_failed": {
     "message": "Indelible save failed: $MESSAGE$",
@@ -50,6 +158,68 @@
   },
   "notify_title": {
     "message": "Indelible"
+  },
+  "open_reader": {
+    "message": "Open reader"
+  },
+  "refresh": {
+    "message": "Refresh"
+  },
+  "reprocess_failed": {
+    "message": "Retry failed"
+  },
+  "reprocess_queued": {
+    "message": "Queued"
+  },
+  "reprocess_queuing": {
+    "message": "Queuing"
+  },
+  "reprocess_retry_in": {
+    "message": "Retry in $SECONDS$s",
+    "placeholders": {
+      "seconds": {
+        "content": "$1"
+      }
+    }
+  },
+  "reprocess_running": {
+    "message": "Running"
+  },
+  "retry": {
+    "message": "Retry"
+  },
+  "retry_processing": {
+    "message": "Retry processing"
+  },
+  "save_note": {
+    "message": "Save note"
+  },
+  "saved_page": {
+    "message": "Saved page"
+  },
+  "saving_detail": {
+    "message": "Extracting readable content and creating the archive"
+  },
+  "saving_status": {
+    "message": "Saving"
+  },
+  "saving_title": {
+    "message": "Saving this page"
+  },
+  "sign_out": {
+    "message": "Sign out"
+  },
+  "star": {
+    "message": "Star"
+  },
+  "tag_placeholder": {
+    "message": "Add tag…"
+  },
+  "tag_remove": {
+    "message": "Remove"
+  },
+  "tags_title": {
+    "message": "Tags"
   },
   "toolbar_highlights_one": {
     "message": "$COUNT$ highlight",
@@ -99,5 +269,20 @@
   },
   "triage_later": {
     "message": "Later"
+  },
+  "try_again": {
+    "message": "Try again"
+  },
+  "unreachable_detail": {
+    "message": "Your session is retained · update the address if your server moved"
+  },
+  "unreachable_title": {
+    "message": "Indelible is unreachable"
+  },
+  "unsupported_detail": {
+    "message": "This type of page cannot be archived"
+  },
+  "unsupported_title": {
+    "message": "Can't save this page"
   }
 }

--- a/extension/public/_locales/fr/messages.json
+++ b/extension/public/_locales/fr/messages.json
@@ -2,8 +2,107 @@
   "action_title": {
     "message": "Indelible"
   },
+  "add": {
+    "message": "Ajouter"
+  },
+  "already_saved_detail": {
+    "message": "Cette page a déjà été enregistrée — actualisez pour la mettre à jour ou créer une nouvelle entrée"
+  },
+  "already_saved_title": {
+    "message": "Déjà dans votre bibliothèque"
+  },
+  "auth_error_detail": {
+    "message": "L'autorisation n'a pas pu démarrer. Veuillez réessayer."
+  },
+  "auth_error_title": {
+    "message": "Connexion impossible"
+  },
+  "auto_highlight": {
+    "message": "Surlignage automatique"
+  },
+  "cancel": {
+    "message": "Annuler"
+  },
+  "checking_detail": {
+    "message": "Recherche d'un élément déjà enregistré"
+  },
+  "checking_status": {
+    "message": "Vérification"
+  },
+  "checking_title": {
+    "message": "Vérification de cette page"
+  },
+  "close": {
+    "message": "Fermer"
+  },
   "command_save_page": {
     "message": "Enregistrer la page actuelle dans Indelible"
+  },
+  "connect": {
+    "message": "Connecter"
+  },
+  "connect_detail": {
+    "message": "Authentifiez votre espace avant d'enregistrer cette page"
+  },
+  "connect_title": {
+    "message": "Connecter Indelible"
+  },
+  "connecting_detail": {
+    "message": "Ouverture de l'autorisation sécurisée du navigateur"
+  },
+  "connecting_status": {
+    "message": "Connexion"
+  },
+  "connecting_title": {
+    "message": "Connexion à Indelible"
+  },
+  "controls_label": {
+    "message": "Commandes Indelible"
+  },
+  "dismiss": {
+    "message": "Masquer"
+  },
+  "error_cannot_save": {
+    "message": "Cette page ne peut pas être enregistrée"
+  },
+  "error_content_script": {
+    "message": "Le script de contenu a échoué"
+  },
+  "error_detail": {
+    "message": "Une erreur est survenue lors de l'enregistrement"
+  },
+  "error_entry_not_found": {
+    "message": "Élément enregistré introuvable"
+  },
+  "error_highlight": {
+    "message": "Le surlignage a échoué"
+  },
+  "error_no_active_tab": {
+    "message": "Aucun onglet actif"
+  },
+  "error_no_selection": {
+    "message": "Aucun texte sélectionné"
+  },
+  "error_reader_save": {
+    "message": "L'enregistrement en mode lecture a échoué"
+  },
+  "error_save_before_highlight": {
+    "message": "Enregistrez la page avant de créer un surlignage"
+  },
+  "error_server_url_invalid": {
+    "message": "L'adresse du serveur est invalide"
+  },
+  "error_server_url_required": {
+    "message": "L'adresse du serveur est requise"
+  },
+  "error_title": {
+    "message": "Une erreur est survenue"
+  },
+  "error_unexpected_response": {
+    "message": "Réponse inattendue du script de contenu"
+  },
+  "error_upload": {
+    "message": "L'envoi a échoué"
   },
   "ext_description": {
     "message": "Enregistrez, archivez et organisez du contenu web avec Indelible"
@@ -16,6 +115,15 @@
   },
   "menu_save_page": {
     "message": "Enregistrer dans Indelible"
+  },
+  "minimize": {
+    "message": "Réduire"
+  },
+  "note_placeholder": {
+    "message": "Ajouter une note sur cet article…"
+  },
+  "note_title": {
+    "message": "Note"
   },
   "notify_failed": {
     "message": "Échec de l’enregistrement dans Indelible : $MESSAGE$",
@@ -50,6 +158,68 @@
   },
   "notify_title": {
     "message": "Indelible"
+  },
+  "open_reader": {
+    "message": "Ouvrir le lecteur"
+  },
+  "refresh": {
+    "message": "Actualiser"
+  },
+  "reprocess_failed": {
+    "message": "Échec de la relance"
+  },
+  "reprocess_queued": {
+    "message": "En file d'attente"
+  },
+  "reprocess_queuing": {
+    "message": "Mise en file"
+  },
+  "reprocess_retry_in": {
+    "message": "Réessayez dans $SECONDS$ s",
+    "placeholders": {
+      "seconds": {
+        "content": "$1"
+      }
+    }
+  },
+  "reprocess_running": {
+    "message": "En cours"
+  },
+  "retry": {
+    "message": "Réessayer"
+  },
+  "retry_processing": {
+    "message": "Relancer le traitement"
+  },
+  "save_note": {
+    "message": "Enregistrer la note"
+  },
+  "saved_page": {
+    "message": "Page enregistrée"
+  },
+  "saving_detail": {
+    "message": "Extraction du contenu lisible et création de l'archive"
+  },
+  "saving_status": {
+    "message": "Enregistrement"
+  },
+  "saving_title": {
+    "message": "Enregistrement de cette page"
+  },
+  "sign_out": {
+    "message": "Se déconnecter"
+  },
+  "star": {
+    "message": "Favori"
+  },
+  "tag_placeholder": {
+    "message": "Ajouter une étiquette…"
+  },
+  "tag_remove": {
+    "message": "Retirer"
+  },
+  "tags_title": {
+    "message": "Étiquettes"
   },
   "toolbar_highlights_one": {
     "message": "$COUNT$ surlignage",
@@ -99,5 +269,20 @@
   },
   "triage_later": {
     "message": "Plus tard"
+  },
+  "try_again": {
+    "message": "Réessayer"
+  },
+  "unreachable_detail": {
+    "message": "Votre session est conservée · mettez à jour l'adresse si votre serveur a changé"
+  },
+  "unreachable_title": {
+    "message": "Indelible est injoignable"
+  },
+  "unsupported_detail": {
+    "message": "Ce type de page ne peut pas être archivé"
+  },
+  "unsupported_title": {
+    "message": "Impossible d'enregistrer cette page"
   }
 }


### PR DESCRIPTION
- toolbar markup, reprocess statuses, and badge/error messages go through t()
- en/fr catalogs extended