### PR TITLE
perf(backend): use mimalloc and disable THP in ind-api and ind-worker

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "ind-search",
  "ind-test-support",
  "ind-worker",
+ "mimalloc",
  "reqwest 0.13.2",
  "secrecy",
  "serde",
@@ -3345,6 +3346,7 @@ dependencies = [
 name = "ind-observability"
 version = "0.1.0"
 dependencies = [
+ "rustix",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3499,6 +3501,7 @@ dependencies = [
  "ind-persistence",
  "ind-search",
  "ind-test-support",
+ "mimalloc",
  "reqwest 0.13.2",
  "secrecy",
  "serde",

--- a/backend/apps/ind-api/Cargo.toml
+++ b/backend/apps/ind-api/Cargo.toml
@@ -10,6 +10,7 @@ name = "ind-api"
 path = "src/main.rs"
 
 [dependencies]
+mimalloc = { workspace = true }
 ind-http-api = { workspace = true }
 ind-config = { workspace = true }
 ind-persistence = { workspace = true }

--- a/backend/apps/ind-api/src/main.rs
+++ b/backend/apps/ind-api/src/main.rs
@@ -1,4 +1,10 @@
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    ind_api::bootstrap::run().await
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+fn main() -> anyhow::Result<()> {
+    ind_observability::process::disable_transparent_huge_pages();
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(ind_api::bootstrap::run())
 }

--- a/backend/apps/ind-worker/Cargo.toml
+++ b/backend/apps/ind-worker/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 test-helpers = []
 
 [dependencies]
+mimalloc = { workspace = true }
 ind-ai = { workspace = true }
 ind-auth = { workspace = true }
 ind-config = { workspace = true }

--- a/backend/apps/ind-worker/src/main.rs
+++ b/backend/apps/ind-worker/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 mod auto_heal;
 mod bootstrap;
 mod concurrency;
@@ -14,7 +17,10 @@ mod repositories;
 mod schedulers;
 mod shutdown;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    bootstrap::run().await
+fn main() -> anyhow::Result<()> {
+    ind_observability::process::disable_transparent_huge_pages();
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(bootstrap::run())
 }

--- a/backend/crates/ind-observability/Cargo.toml
+++ b/backend/crates/ind-observability/Cargo.toml
@@ -11,3 +11,6 @@ tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "1", features = ["thread"] }

--- a/backend/crates/ind-observability/src/lib.rs
+++ b/backend/crates/ind-observability/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod process;
+
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;

--- a/backend/crates/ind-observability/src/process.rs
+++ b/backend/crates/ind-observability/src/process.rs
@@ -1,11 +1,12 @@
 //! Process-level tuning applied before the async runtime starts.
 
 // With THP=always, the kernel backs allocator arenas with 2 MiB pages and triples idle RSS.
-// Must run before the runtime and allocator touch any large region.
+// Must run before the runtime and allocator touch any large region; tracing is not up yet,
+// so a failure goes straight to stderr.
 #[cfg(target_os = "linux")]
 pub fn disable_transparent_huge_pages() {
     if let Err(err) = rustix::thread::disable_transparent_huge_pages(true) {
-        tracing::warn!(%err, "could not disable transparent huge pages");
+        eprintln!("could not disable transparent huge pages: {err}");
     }
 }
 

--- a/backend/crates/ind-observability/src/process.rs
+++ b/backend/crates/ind-observability/src/process.rs
@@ -1,0 +1,13 @@
+//! Process-level tuning applied before the async runtime starts.
+
+// With THP=always, the kernel backs allocator arenas with 2 MiB pages and triples idle RSS.
+// Must run before the runtime and allocator touch any large region.
+#[cfg(target_os = "linux")]
+pub fn disable_transparent_huge_pages() {
+    if let Err(err) = rustix::thread::disable_transparent_huge_pages(true) {
+        tracing::warn!(%err, "could not disable transparent huge pages");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn disable_transparent_huge_pages() {}


### PR DESCRIPTION
- ind-api and ind-worker use mimalloc, matching ind-renderer
- disable transparent huge pages per process before the runtime starts (`ind_observability::process`)