### PR TITLE
docs: document browser extension store releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ships a production compose file, and the
 | Client | Where |
 | --- | --- |
 | Web | Served by `ind-api`, no separate deployment |
-| Browser extension | `extension/` (Chrome, Edge, Firefox) |
+| Browser extension | [Chrome and Edge](https://chromewebstore.google.com/detail/indelible/jidilhjojlgndbpeooeeceohmkedooef), [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/indelible/), or [source](extension/) |
 | Mobile | `mobile/` (Android and iOS, Kotlin Multiplatform) |
 | Obsidian plugin | `obsidian/` |
 

--- a/website/src/content/docs/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/docs/getting-started/quick-start.md
@@ -20,7 +20,8 @@ Indelible Cloud (managed hosting, zero setup) is coming soon.
 
 ## Saving content
 
-- **Browser extension**: one-click save from Chrome or Firefox.
+- **[Browser extension](/docs/how-to/browser-extension/)**: one-click save from
+  Chrome, Edge, and Firefox.
 - **Email**: every account gets personal email addresses for newsletters and
   one-off forwards. See [Save content by email](/docs/how-to/save-by-email/).
 - **In the app**: paste URLs or upload PDFs, EPUBs, and HTML files.

--- a/website/src/content/docs/docs/how-to/browser-extension.md
+++ b/website/src/content/docs/docs/how-to/browser-extension.md
@@ -10,8 +10,14 @@ Edge.
 
 ## Install
 
-The extension isn't in the web stores yet. For now, build it from source and load it
-unpacked:
+- **Chrome**: [install from the Chrome Web Store](https://chromewebstore.google.com/detail/indelible/jidilhjojlgndbpeooeeceohmkedooef).
+- **Microsoft Edge**: install from the same [Chrome Web Store listing](https://chromewebstore.google.com/detail/indelible/jidilhjojlgndbpeooeeceohmkedooef).
+  Edge may first ask you to allow extensions from other stores.
+- **Firefox**: [install from Firefox Add-ons](https://addons.mozilla.org/en-GB/firefox/addon/indelible/).
+
+## Build from source
+
+To test an unreleased build or contribute to the extension, build it locally:
 
 ```bash
 cd extension


### PR DESCRIPTION
## Summary

- Add Chrome, Edge, and Firefox store install links.
- Keep sideloading instructions under **Build from source**.
- Update Quick Start and README extension links.

## Checks

- `pnpm check`
- `pnpm test:seo`
