### PR TITLE
fix release draft lookup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
             echo "::error::release_tag must be a stable vX.Y.Z tag"
             exit 1
           fi
-          release="$(gh release view "$RELEASE_TAG" --json isDraft,assets)"
+          release="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,assets)"
           draft="$(jq -r '.isDraft' <<< "$release")"
           if [[ "$draft" != "true" ]]; then
             echo "::error::$RELEASE_TAG must identify an unpublished draft release"


### PR DESCRIPTION
## Change

- Pass the repository explicitly to `gh release view`.

## Checks

- Reproduced the lookup outside a Git checkout.
- Actionlint.
- `git diff --check`.