### PR TITLE
fix(release): allow draft lookup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ jobs:
     name: Resolve build source
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       mode: ${{ steps.source.outputs.mode }}
       ref: ${{ steps.source.outputs.ref }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -426,7 +426,7 @@ jobs:
     name: Build exact release images
     needs: prepare
     permissions:
-      contents: read
+      contents: write
       packages: write
     uses: ./.github/workflows/docker.yml
     with:


### PR DESCRIPTION
## Change

- Allow the release resolver to read unpublished drafts.
- Keep image build jobs read-only.

## Checks

- Permission-scope assertions.
- Actionlint.
- `git diff --check`.