### PR TITLE
fix(release): set repository context

### DIFF
--- a/.github/workflows/android-aab-backfill.yml
+++ b/.github/workflows/android-aab-backfill.yml
@@ -14,6 +14,9 @@ on:
         required: true
         default: v0.1.0
 
+env:
+  GH_REPO: ${{ github.repository }}
+
 permissions:
   contents: write
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ on:
     types: [completed]
     branches: [main]
 
+env:
+  GH_REPO: ${{ github.repository }}
+
 permissions:
   contents: read
   packages: write
@@ -61,7 +64,7 @@ jobs:
             echo "::error::release_tag must be a stable vX.Y.Z tag"
             exit 1
           fi
-          release="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,assets)"
+          release="$(gh release view "$RELEASE_TAG" --json isDraft,assets)"
           draft="$(jq -r '.isDraft' <<< "$release")"
           if [[ "$draft" != "true" ]]; then
             echo "::error::$RELEASE_TAG must identify an unpublished draft release"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,6 +9,9 @@ on:
         type: choice
         options: [patch, minor, major]
 
+env:
+  GH_REPO: ${{ github.repository }}
+
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  GH_REPO: ${{ github.repository }}
+
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
## Change
- Set `GH_REPO` in release workflows.
- Remove ambient Git checkout dependency.

## Checks
- Repository-context assertion
- Draft lookup outside Git checkout
- Actionlint
- `git diff --check`