### PR TITLE
fix(release): read draft image manifest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -188,6 +188,9 @@ jobs:
     name: Publish ${{ matrix.image }} manifest
     needs: [resolve, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Change
- Grant the Docker manifest job access to draft release assets.

## Checks
- Permission invariant
- Actionlint
- `git diff --check`