### PR TITLE
docs: add product screenshots to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img alt="An archived article open in the Indelible reader, with Mila's summary, extracted metadata and reading progress in the detail panel beside it" src="https://assets.useindelible.com/readme/reader.webp" width="100%" />
+
 # Indelible
 
 Open-source, self-hosted read-it-later and knowledge archiver. Articles,
@@ -18,6 +20,14 @@ library, permanently. Links rot; your library does not.
 - **Content in, from anywhere.** Browser extension, personal email-in
   addresses, RSS feeds, and file uploads.
 - **Your tools, connected.** Sync to Obsidian and Notion.
+
+<img alt="Four Indelible screens: the Home dashboard, full-text and semantic search, Collections, and the RSS feed" src="https://assets.useindelible.com/readme/wall.webp" width="100%" />
+
+Mila is optional and runs on your own provider key, against any
+OpenAI-compatible endpoint. It summarizes, tags, and answers questions across
+the library.
+
+<img alt="Indelible's Mila settings, showing the provider toggle, library indexing progress, and the editable summary and tag prompt presets" src="https://assets.useindelible.com/readme/mila.webp" width="100%" />
 
 ## Quick start
 
@@ -57,6 +67,20 @@ docker compose up -d --build
 | Browser extension | [Chrome and Edge](https://chromewebstore.google.com/detail/indelible/jidilhjojlgndbpeooeeceohmkedooef), [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/indelible/), or [source](extension/) |
 | Mobile | `mobile/` (Android and iOS, Kotlin Multiplatform) |
 | Obsidian plugin | `obsidian/` |
+
+Android and iOS are one Kotlin Multiplatform codebase, sharing the library and
+reading position with the web.
+
+<img alt="Three Indelible phone screens: the daily home view, an article being highlighted with the native selection toolbar, and saving a URL" src="https://assets.useindelible.com/readme/phones.webp" width="100%" />
+
+The extension saves the page you are on and archives its full text at save
+time, without leaving the tab. Highlights travel both ways: text you mark on
+the live page shows up in the reader, and highlights made in the reader are
+re-anchored onto the original page when you open the extension there again.
+Notes attach to a saved page from the extension, or to an individual highlight
+in the web app.
+
+<img alt="The Indelible browser extension toolbar injected over an article it has just saved, with a highlight in the page text" src="https://assets.useindelible.com/readme/extension.webp" width="100%" />
 
 ## Documentation
 


### PR DESCRIPTION
The README had no images. Adds five: reader hero above the title, a four-screen wall, Mila's settings, the phone trio, the extension.

**Hosting**
- Served from `assets.useindelible.com` (Cloudflare R2), not committed. They change whenever the UI does, and binaries cannot be reclaimed from git history
- Stable paths, so a refresh overwrites in place and touches no README lines
- WebP, 756KB across all five, one theme
- Verified: all five return HTTP 200, `image/webp`, byte for byte identical to the rendered originals
- Cloudflare returns `cache-control: max-age=14400`, which GitHub's camo proxy passes through

**Copy**
- Extension paragraph now covers highlights in both directions and the two note scopes: page level from the extension, per highlight in the web app
- Both traced in code first; reader to live page re-anchoring at `extension/lib/full-archive-toolbar.ts:121`

No repository files added. The render harness is deliberately not committed.
