### PR TITLE
feat(api): accept client highlight ids

### DIFF
--- a/backend/.sqlx/query-ee2f4f34deb744ad4bc55cdbdafd076cb82da081d227cc0966bd09ab7d807be1.json
+++ b/backend/.sqlx/query-ee2f4f34deb744ad4bc55cdbdafd076cb82da081d227cc0966bd09ab7d807be1.json
@@ -1,0 +1,77 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO highlights (id, document_id, user_id, color, text_content, locator, source_locator, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8) ON CONFLICT DO NOTHING RETURNING id, document_id AS \"document_id!\", user_id, color, text_content, locator, source_locator, created_at, updated_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "document_id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "color",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "text_content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "locator",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "source_locator",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Jsonb",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "ee2f4f34deb744ad4bc55cdbdafd076cb82da081d227cc0966bd09ab7d807be1"
+}

--- a/backend/apps/ind-api/tests/api.rs
+++ b/backend/apps/ind-api/tests/api.rs
@@ -22,6 +22,7 @@ mod api {
     mod extension_auth_journey_tests;
     mod feed_route_permission_tests;
     mod feed_subscription_journey_tests;
+    mod highlight_idempotency_tests;
     mod highlight_text_quote_tests;
     mod integration_availability_tests;
     mod integration_journey_tests;

--- a/backend/apps/ind-api/tests/api/highlight_idempotency_tests.rs
+++ b/backend/apps/ind-api/tests/api/highlight_idempotency_tests.rs
@@ -9,6 +9,10 @@ use serde_json::{Value, json};
 
 use super::common::assert_json_response;
 
+/// Two in-flight writers can serialize by luck; eight cannot, so the losers really do meet a
+/// primary key the winner has not committed yet.
+const CONCURRENT_WRITERS: usize = 8;
+
 const ID: &str = "hlt_018f5b1e-0000-7000-8000-000000000001";
 const HIGHLIGHTED_EVENT: &str = "document.highlighted";
 
@@ -148,26 +152,25 @@ async fn concurrent_identical_creates_produce_one_highlight() {
     let doc = readable_article(&app, session.user.id).await;
     let request = body(Some(ID), "selected", None);
 
-    let (first, second) = tokio::join!(
-        create(&client, &doc, &request),
-        create(&client, &doc, &request)
-    );
-    let mut statuses = [first.status(), second.status()];
-    let bodies = [
-        first.text().await.expect("read body"),
-        second.text().await.expect("read body"),
-    ];
-    statuses.sort_by_key(StatusCode::as_u16);
+    let responses =
+        futures::future::join_all((0..CONCURRENT_WRITERS).map(|_| create(&client, &doc, &request)))
+            .await;
 
-    assert_eq!(
-        statuses,
-        [StatusCode::OK, StatusCode::CREATED],
-        "bodies: {bodies:?}"
-    );
-    for raw in &bodies {
-        let parsed: Value = serde_json::from_str(raw).expect("response was JSON");
+    let mut created = 0;
+    let mut replayed = 0;
+    for response in responses {
+        let status = response.status();
+        let raw = response.text().await.expect("read body");
+        match status {
+            StatusCode::CREATED => created += 1,
+            StatusCode::OK => replayed += 1,
+            other => panic!("unexpected {other}: {raw}"),
+        }
+        let parsed: Value = serde_json::from_str(&raw).expect("response was JSON");
         assert_eq!(parsed["id"], ID);
     }
+
+    assert_eq!((created, replayed), (1, CONCURRENT_WRITERS - 1));
     assert_eq!(count(&client, &doc).await, 1);
 }
 

--- a/backend/apps/ind-api/tests/api/highlight_idempotency_tests.rs
+++ b/backend/apps/ind-api/tests/api/highlight_idempotency_tests.rs
@@ -1,0 +1,228 @@
+use ind_application::repos::document_asset::DocumentAssetRepository;
+use ind_domain::{
+    ArchiveAssetKind, ArchiveAssetStatus, DocumentType, NewDocumentAsset, UserId, job_types,
+};
+use ind_persistence::repos::PgDocumentAssetRepository;
+use ind_test_support::{AuthedClient, DocumentFactory, TestApp, spawn_app};
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+
+use super::common::assert_json_response;
+
+const ID: &str = "hlt_018f5b1e-0000-7000-8000-000000000001";
+const HIGHLIGHTED_EVENT: &str = "document.highlighted";
+
+fn body(id: Option<&str>, text: &str, source: Option<Value>) -> Value {
+    let mut body = json!({
+        "color": "yellow",
+        "text_content": text,
+        "locator": {"type": "html", "start_offset": 0, "end_offset": 8}
+    });
+    if let Some(id) = id {
+        body["id"] = json!(id);
+    }
+    if let Some(source) = source {
+        body["source_locator"] = source;
+    }
+    body
+}
+
+fn quote(prefix: &str) -> Value {
+    json!({"type": "text_quote", "prefix": prefix, "suffix": null})
+}
+
+async fn readable_article(app: &TestApp, user_id: UserId) -> String {
+    let document = DocumentFactory::new(user_id)
+        .with_document_type(DocumentType::Article)
+        .insert(app.pool())
+        .await;
+    PgDocumentAssetRepository::new(app.pool().clone())
+        .upsert_document_asset(NewDocumentAsset {
+            document_id: document.id,
+            asset_kind: ArchiveAssetKind::ReadableHtml,
+            s3_key: format!("tests/idempotency/{}", document.id),
+            s3_bucket: "test-bucket".into(),
+            content_type: "text/html".into(),
+            size_bytes: 64,
+            status: ArchiveAssetStatus::Completed,
+            failed_reason: None,
+        })
+        .await
+        .unwrap();
+    document.id.to_string()
+}
+
+async fn create(client: &AuthedClient<'_>, doc: &str, body: &Value) -> reqwest::Response {
+    client
+        .post_json(&format!("/api/v1/documents/{doc}/highlights"), body)
+        .await
+}
+
+async fn create_expecting(
+    client: &AuthedClient<'_>,
+    doc: &str,
+    body: &Value,
+    status: StatusCode,
+) -> Value {
+    assert_json_response(create(client, doc, body).await, status).await
+}
+
+async fn count(client: &AuthedClient<'_>, doc: &str) -> u64 {
+    let listed = assert_json_response(
+        client
+            .get(&format!("/api/v1/documents/{doc}/highlights"))
+            .await,
+        StatusCode::OK,
+    )
+    .await;
+    listed["count"].as_u64().expect("count is a number")
+}
+
+fn reindex_dedupe_key(doc: &str) -> String {
+    format!("{}:{doc}", job_types::SEARCH_REINDEX_DOCUMENT)
+}
+
+async fn highlighted_events(app: &TestApp, highlight_id: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT count(*) FROM domain_events \
+         WHERE event_type = $1 AND payload->>'highlight_id' = $2",
+    )
+    .bind(HIGHLIGHTED_EVENT)
+    .bind(highlight_id)
+    .fetch_one(app.pool())
+    .await
+    .expect("count document.highlighted events")
+}
+
+/// Row count plus undispatched count, because a repeated side-effect run upserts the reindex
+/// row on its dedupe key rather than inserting a second one; only `dispatched_at` moves.
+async fn reindex_outbox(app: &TestApp, doc: &str) -> (i64, i64) {
+    sqlx::query_as::<_, (i64, i64)>(
+        "SELECT count(*), count(*) FILTER (WHERE dispatched_at IS NULL) FROM job_outbox \
+         WHERE job_type = $1 AND dedupe_key = $2",
+    )
+    .bind(job_types::SEARCH_REINDEX_DOCUMENT)
+    .bind(reindex_dedupe_key(doc))
+    .fetch_one(app.pool())
+    .await
+    .expect("count search reindex outbox rows")
+}
+
+async fn mark_reindex_dispatched(app: &TestApp, doc: &str) {
+    let updated = sqlx::query(
+        "UPDATE job_outbox SET dispatched_at = now() WHERE job_type = $1 AND dedupe_key = $2",
+    )
+    .bind(job_types::SEARCH_REINDEX_DOCUMENT)
+    .bind(reindex_dedupe_key(doc))
+    .execute(app.pool())
+    .await
+    .expect("mark reindex dispatched")
+    .rows_affected();
+    assert_eq!(updated, 1, "expected exactly one reindex row to dispatch");
+}
+
+#[tokio::test]
+async fn exact_replay_returns_the_existing_highlight() {
+    let app = spawn_app().await;
+    let session = app.create_web_session().await;
+    let client = app.authed_client(&session);
+    let doc = readable_article(&app, session.user.id).await;
+    let request = body(Some(ID), "selected", Some(quote("before ")));
+
+    let created = create_expecting(&client, &doc, &request, StatusCode::CREATED).await;
+    let replayed = create_expecting(&client, &doc, &request, StatusCode::OK).await;
+
+    assert_eq!(created["id"], ID);
+    assert_eq!(replayed["id"], ID);
+    assert_eq!(replayed["created_at"], created["created_at"]);
+    assert_eq!(replayed["updated_at"], created["updated_at"]);
+    assert_eq!(replayed["source_locator"], created["source_locator"]);
+    assert_eq!(count(&client, &doc).await, 1);
+}
+
+#[tokio::test]
+async fn concurrent_identical_creates_produce_one_highlight() {
+    let app = spawn_app().await;
+    let session = app.create_web_session().await;
+    let client = app.authed_client(&session);
+    let doc = readable_article(&app, session.user.id).await;
+    let request = body(Some(ID), "selected", None);
+
+    let (first, second) = tokio::join!(
+        create(&client, &doc, &request),
+        create(&client, &doc, &request)
+    );
+    let mut statuses = [first.status(), second.status()];
+    let bodies = [
+        first.text().await.expect("read body"),
+        second.text().await.expect("read body"),
+    ];
+    statuses.sort_by_key(StatusCode::as_u16);
+
+    assert_eq!(
+        statuses,
+        [StatusCode::OK, StatusCode::CREATED],
+        "bodies: {bodies:?}"
+    );
+    for raw in &bodies {
+        let parsed: Value = serde_json::from_str(raw).expect("response was JSON");
+        assert_eq!(parsed["id"], ID);
+    }
+    assert_eq!(count(&client, &doc).await, 1);
+}
+
+#[tokio::test]
+async fn reused_id_with_different_content_or_owner_conflicts() {
+    let app = spawn_app().await;
+    let owner = app.create_web_session().await;
+    let stranger = app.create_web_session().await;
+    let owner_client = app.authed_client(&owner);
+    let stranger_client = app.authed_client(&stranger);
+    let first = readable_article(&app, owner.user.id).await;
+    let second = readable_article(&app, owner.user.id).await;
+    let strangers = readable_article(&app, stranger.user.id).await;
+    let stored = body(Some(ID), "selected", Some(quote("a")));
+
+    create_expecting(&owner_client, &first, &stored, StatusCode::CREATED).await;
+    for divergent in [
+        body(Some(ID), "different", Some(quote("a"))),
+        body(Some(ID), "selected", Some(quote("b"))),
+        body(Some(ID), "selected", None),
+    ] {
+        create_expecting(&owner_client, &first, &divergent, StatusCode::CONFLICT).await;
+    }
+    create_expecting(&owner_client, &second, &stored, StatusCode::CONFLICT).await;
+    create_expecting(&stranger_client, &strangers, &stored, StatusCode::CONFLICT).await;
+
+    let bare_uuid = body(
+        Some("018f5b1e-0000-7000-8000-000000000001"),
+        "selected",
+        None,
+    );
+    create_expecting(&owner_client, &first, &bare_uuid, StatusCode::BAD_REQUEST).await;
+    let generated = body(None, "no id still works", None);
+    create_expecting(&owner_client, &first, &generated, StatusCode::CREATED).await;
+
+    assert_eq!(count(&owner_client, &first).await, 2);
+    assert_eq!(count(&owner_client, &second).await, 0);
+    assert_eq!(count(&stranger_client, &strangers).await, 0);
+}
+
+#[tokio::test]
+async fn replay_does_not_repeat_highlight_side_effects() {
+    let app = spawn_app().await;
+    let session = app.create_web_session().await;
+    let client = app.authed_client(&session);
+    let doc = readable_article(&app, session.user.id).await;
+    let request = body(Some(ID), "selected", Some(quote("before ")));
+
+    create_expecting(&client, &doc, &request, StatusCode::CREATED).await;
+    assert_eq!(highlighted_events(&app, ID).await, 1);
+    assert_eq!(reindex_outbox(&app, &doc).await, (1, 1));
+    mark_reindex_dispatched(&app, &doc).await;
+
+    create_expecting(&client, &doc, &request, StatusCode::OK).await;
+
+    assert_eq!(highlighted_events(&app, ID).await, 1);
+    assert_eq!(reindex_outbox(&app, &doc).await, (1, 0));
+}

--- a/backend/apps/ind-api/tests/api/save_pipeline/core.rs
+++ b/backend/apps/ind-api/tests/api/save_pipeline/core.rs
@@ -180,6 +180,38 @@ async fn extension_check_url_annotations_share_the_saved_document_contract() {
     assert_eq!(listed["count"], 1);
     assert_eq!(listed["highlights"][0]["id"], highlight["id"]);
 
+    let queued = serde_json::json!({
+        "id": "hlt_018f5b1e-0000-7000-8000-0000000000e1",
+        "color": "yellow",
+        "text_content": "Queued while offline",
+        "locator": {"type": "html", "start_offset": 18, "end_offset": 38}
+    });
+    assert_eq!(
+        client.post_json(&highlights_path, &queued).await.status(),
+        StatusCode::CREATED
+    );
+    let replayed = assert_json_response(
+        client.post_json(&highlights_path, &queued).await,
+        StatusCode::OK,
+    )
+    .await;
+    assert_eq!(replayed["id"], queued["id"]);
+    assert_eq!(
+        client
+            .post_json(
+                &highlights_path,
+                &serde_json::json!({
+                    "id": "018f5b1e-0000-7000-8000-0000000000e1",
+                    "color": "yellow",
+                    "text_content": "unprefixed id",
+                    "locator": {"type": "html", "start_offset": 0, "end_offset": 4}
+                }),
+            )
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+
     let note_path = format!("/api/v1/extension/entries/{entry_id}/note");
     let note = assert_json_response(
         client

--- a/backend/crates/ind-application/src/handlers/document_reader/mod.rs
+++ b/backend/crates/ind-application/src/handlers/document_reader/mod.rs
@@ -9,9 +9,8 @@ use std::time::Duration;
 use chrono::Utc;
 use ind_domain::{
     ArchiveAssetKind, ArchiveAssetStatus, Document, DocumentAsset, DocumentId, DocumentNote,
-    DocumentType, DomainError, EventOrigin, Highlight, HighlightId, HighlightLocator,
-    HighlightSourceLocator, NewHighlight, NewReadingEvent, ReadingPosition, UserDocumentState,
-    UserId,
+    DocumentType, DomainError, EventOrigin, Highlight, HighlightId, NewHighlight, NewReadingEvent,
+    ReadingPosition, UserDocumentState, UserId,
 };
 
 use futures::future::BoxFuture;
@@ -22,13 +21,16 @@ use crate::handlers::highlight::HighlightWithNote;
 use crate::handlers::highlight::validation::{
     validate_color, validate_highlight_locators_for_document,
 };
-use crate::ports::{DocumentReaderOperations, DocumentReaderView, DocumentReprocessOutput};
+use crate::ports::{
+    CreateHighlightRequest, DocumentReaderOperations, DocumentReaderView, DocumentReprocessOutput,
+    HighlightCreation,
+};
 use crate::repos::document::DocumentRepository;
 use crate::repos::document_asset::DocumentAssetRepository;
 use crate::repos::document_note::DocumentNoteRepository;
 use crate::repos::document_reprocess::DocumentReprocessRepository;
 use crate::repos::event::MutationSideEffects;
-use crate::repos::highlight::HighlightRepository;
+use crate::repos::highlight::{HighlightRepository, HighlightWrite};
 use crate::repos::library::LibraryRepository;
 use crate::repos::lifecycle_outbox::search_reindex_document_outbox;
 use crate::repos::user_document_state::{AppendOutcome, UserDocumentStateRepository};
@@ -208,37 +210,52 @@ impl DocumentReaderService {
         &self,
         user_id: UserId,
         document_id: DocumentId,
-        color: String,
-        text_content: String,
-        locator: Option<HighlightLocator>,
-        source_locator: Option<HighlightSourceLocator>,
-    ) -> Result<Highlight, AppError> {
+        request: CreateHighlightRequest,
+    ) -> Result<HighlightCreation, AppError> {
         let document = self.require_document(user_id, document_id).await?;
         self.require_annotation_source(&document).await?;
-        validate_color(&color)?;
+        validate_color(&request.color)?;
         validate_highlight_locators_for_document(
             document.document_type,
-            locator.as_ref(),
-            source_locator.as_ref(),
+            request.locator.as_ref(),
+            request.source_locator.as_ref(),
         )?;
 
         let new_highlight = NewHighlight {
-            id: HighlightId::new(),
+            id: request.requested_id.unwrap_or_else(HighlightId::new),
             document_id,
             user_id,
-            color,
-            text_content,
-            locator,
-            source_locator,
+            color: request.color,
+            text_content: request.text_content,
+            locator: request.locator,
+            source_locator: request.source_locator,
         };
         let now = Utc::now();
         let effects = MutationSideEffects {
             events: vec![document_highlighted(user_id, document_id, new_highlight.id)],
             outbox: vec![search_reindex_document_outbox(document_id, now)],
         };
-        self.highlight_repo
+
+        match self
+            .highlight_repo
             .create_for_document(&new_highlight, effects)
-            .await
+            .await?
+        {
+            HighlightWrite::Inserted(highlight) => Ok(HighlightCreation {
+                highlight: *highlight,
+                created: true,
+            }),
+            HighlightWrite::IdTaken => {
+                match self
+                    .highlight_repo
+                    .get_by_id(new_highlight.id, user_id)
+                    .await?
+                {
+                    Some(existing) => replay_or_conflict(existing, &new_highlight),
+                    None => Err(highlight_id_conflict(new_highlight.id)),
+                }
+            }
+        }
     }
 
     pub async fn list_highlights(
@@ -355,19 +372,9 @@ impl DocumentReaderOperations for DocumentReaderService {
         &self,
         user_id: UserId,
         document_id: DocumentId,
-        color: String,
-        text_content: String,
-        locator: Option<HighlightLocator>,
-        source_locator: Option<HighlightSourceLocator>,
-    ) -> BoxFuture<'_, Result<Highlight, AppError>> {
-        Box::pin(self.create_highlight(
-            user_id,
-            document_id,
-            color,
-            text_content,
-            locator,
-            source_locator,
-        ))
+        request: CreateHighlightRequest,
+    ) -> BoxFuture<'_, Result<HighlightCreation, AppError>> {
+        Box::pin(self.create_highlight(user_id, document_id, request))
     }
 
     fn list_highlights(
@@ -414,4 +421,32 @@ impl DocumentReaderOperations for DocumentReaderService {
     ) -> BoxFuture<'_, Result<AppendOutcome, AppError>> {
         Box::pin(self.append_reading_events(user_id, document_id, events))
     }
+}
+
+/// `created_at` and `updated_at` are stamped server-side, so comparing them would make every
+/// retry read as divergent; only client-supplied content decides replay versus conflict.
+fn replay_or_conflict(
+    existing: Highlight,
+    requested: &NewHighlight,
+) -> Result<HighlightCreation, AppError> {
+    let same = existing.document_id == requested.document_id
+        && existing.color == requested.color
+        && existing.text_content == requested.text_content
+        && existing.locator == requested.locator
+        && existing.source_locator == requested.source_locator;
+    if same {
+        Ok(HighlightCreation {
+            highlight: existing,
+            created: false,
+        })
+    } else {
+        Err(highlight_id_conflict(requested.id))
+    }
+}
+
+fn highlight_id_conflict(id: HighlightId) -> AppError {
+    AppError::Domain(DomainError::Conflict {
+        entity: "Highlight",
+        message: format!("highlight {id} already exists with different content"),
+    })
 }

--- a/backend/crates/ind-application/src/handlers/document_reader/mod.rs
+++ b/backend/crates/ind-application/src/handlers/document_reader/mod.rs
@@ -221,8 +221,9 @@ impl DocumentReaderService {
             request.source_locator.as_ref(),
         )?;
 
+        let requested_id = request.requested_id;
         let new_highlight = NewHighlight {
-            id: request.requested_id.unwrap_or_else(HighlightId::new),
+            id: requested_id.unwrap_or_else(HighlightId::new),
             document_id,
             user_id,
             color: request.color,
@@ -245,6 +246,9 @@ impl DocumentReaderService {
                 highlight: *highlight,
                 created: true,
             }),
+            HighlightWrite::IdTaken if requested_id.is_none() => {
+                Err(highlight_id_conflict(new_highlight.id))
+            }
             HighlightWrite::IdTaken => {
                 match self
                     .highlight_repo

--- a/backend/crates/ind-application/src/ports/content/document_reader.rs
+++ b/backend/crates/ind-application/src/ports/content/document_reader.rs
@@ -15,6 +15,23 @@ pub struct DocumentReaderView {
     pub assets: Vec<DocumentAsset>,
 }
 
+pub struct CreateHighlightRequest {
+    /// Caller-supplied id. `None` lets the server mint one, which is never a replay.
+    pub requested_id: Option<HighlightId>,
+    pub color: String,
+    pub text_content: String,
+    pub locator: Option<HighlightLocator>,
+    pub source_locator: Option<HighlightSourceLocator>,
+}
+
+/// Outcome of a highlight create. `created` is false when a caller-supplied id replayed an
+/// identical highlight, which the HTTP layer answers with 200 instead of 201.
+#[derive(Debug, Clone)]
+pub struct HighlightCreation {
+    pub highlight: Highlight,
+    pub created: bool,
+}
+
 pub struct DocumentReprocessOutput {
     pub queued: bool,
     pub job_type: String,
@@ -51,11 +68,8 @@ pub trait DocumentReaderOperations: Send + Sync {
         &self,
         user_id: UserId,
         document_id: DocumentId,
-        color: String,
-        text_content: String,
-        locator: Option<HighlightLocator>,
-        source_locator: Option<HighlightSourceLocator>,
-    ) -> BoxFuture<'_, Result<Highlight, AppError>>;
+        request: CreateHighlightRequest,
+    ) -> BoxFuture<'_, Result<HighlightCreation, AppError>>;
 
     fn list_highlights(
         &self,

--- a/backend/crates/ind-application/src/ports/mod.rs
+++ b/backend/crates/ind-application/src/ports/mod.rs
@@ -27,15 +27,15 @@ pub use auth::{
 };
 pub use content::{
     ArticleTocOperations, ArticleTocReadOutput, CollectionOperations, CreateCollectionRequest,
-    CreateSmartListRequest, CreateTagRequest, DocumentReaderOperations, DocumentReaderView,
-    DocumentReprocessOutput, EntityOperations, ExtensionSaveOperations, FeedDeliveryOperations,
-    FeedOperations, FeedOpmlImportResult, FeedPreparationOperations, FeedSubscribeResult,
-    FileUploadProcessor, HighlightOperations, HomeOperations, LibraryOperations,
-    LibraryUploadOperations, LibraryUrlCheckResult, PatchExtensionEntryRequest,
-    PrepareDeliveryOutcome, ProcessedUpload, ProcessedUploadAsset, ReadAheadOutcome,
-    SaveUrlRequest, SearchOperations, SettingsOperations, SmartListOperations, TagOperations,
-    UpdateCollectionRequest, UpdateEntityRequest, UpdateSmartListRequest, UpdateTagRequest,
-    UploadFileProcessRequest, UploadFileRequest,
+    CreateHighlightRequest, CreateSmartListRequest, CreateTagRequest, DocumentReaderOperations,
+    DocumentReaderView, DocumentReprocessOutput, EntityOperations, ExtensionSaveOperations,
+    FeedDeliveryOperations, FeedOperations, FeedOpmlImportResult, FeedPreparationOperations,
+    FeedSubscribeResult, FileUploadProcessor, HighlightCreation, HighlightOperations,
+    HomeOperations, LibraryOperations, LibraryUploadOperations, LibraryUrlCheckResult,
+    PatchExtensionEntryRequest, PrepareDeliveryOutcome, ProcessedUpload, ProcessedUploadAsset,
+    ReadAheadOutcome, SaveUrlRequest, SearchOperations, SettingsOperations, SmartListOperations,
+    TagOperations, UpdateCollectionRequest, UpdateEntityRequest, UpdateSmartListRequest,
+    UpdateTagRequest, UploadFileProcessRequest, UploadFileRequest,
 };
 pub use egress::{OutboundUrlGuard, UrlGuardError};
 pub use feed_parser::{

--- a/backend/crates/ind-application/src/repos/highlight.rs
+++ b/backend/crates/ind-application/src/repos/highlight.rs
@@ -23,9 +23,11 @@ pub trait HighlightRepository: Send + Sync {
         highlight: &NewHighlight,
         effects: MutationSideEffects,
     ) -> Result<Highlight, AppError>;
-    /// Create a document-keyed highlight (`item_id` NULL) and commit any `effects` (the
-    /// `document.highlighted` event plus document search reindex / embed outbox rows) atomically
-    /// with the annotation. An id already present yields `IdTaken` with nothing written.
+    /// Create a highlight and commit any `effects` (the `document.highlighted` event plus
+    /// document search reindex / embed outbox rows) atomically with the annotation. An id
+    /// already present yields `IdTaken` with nothing written, so a retry is safe; callers
+    /// resolving `IdTaken` compare against the stored row, which a later mutation such as
+    /// `update_color` can move out from under a still-queued retry.
     async fn create_for_document(
         &self,
         highlight: &NewHighlight,

--- a/backend/crates/ind-application/src/repos/highlight.rs
+++ b/backend/crates/ind-application/src/repos/highlight.rs
@@ -8,6 +8,14 @@ use ind_domain::{
     DocumentId, Highlight, HighlightId, HighlightNote, NewHighlight, Tag, TagId, UserId,
 };
 
+/// Result of a create keyed on a caller-supplied id. `IdTaken` means the row already existed
+/// and no side effects were applied, so a replay never re-emits events or reindex work.
+#[derive(Debug)]
+pub enum HighlightWrite {
+    Inserted(Box<Highlight>),
+    IdTaken,
+}
+
 #[async_trait::async_trait]
 pub trait HighlightRepository: Send + Sync {
     async fn create(
@@ -17,12 +25,12 @@ pub trait HighlightRepository: Send + Sync {
     ) -> Result<Highlight, AppError>;
     /// Create a document-keyed highlight (`item_id` NULL) and commit any `effects` (the
     /// `document.highlighted` event plus document search reindex / embed outbox rows) atomically
-    /// with the annotation.
+    /// with the annotation. An id already present yields `IdTaken` with nothing written.
     async fn create_for_document(
         &self,
         highlight: &NewHighlight,
         effects: MutationSideEffects,
-    ) -> Result<Highlight, AppError>;
+    ) -> Result<HighlightWrite, AppError>;
     async fn list_by_document(
         &self,
         document_id: DocumentId,
@@ -99,7 +107,7 @@ pub trait HighlightRepository: Send + Sync {
         user_id: UserId,
     ) -> Result<HashMap<HighlightId, Vec<Tag>>, AppError>;
 
-    /// Cursor-paginated highlights for a document, used by the Notion export job (TASK-236).
+    /// Cursor-paginated highlights for a document, ordered by `(created_at, id)` ascending.
     async fn list_by_document_after_cursor(
         &self,
         document_id: DocumentId,

--- a/backend/crates/ind-domain/src/highlight.rs
+++ b/backend/crates/ind-domain/src/highlight.rs
@@ -36,7 +36,7 @@ pub struct Highlight {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum HighlightLocator {
     Html {
@@ -102,5 +102,52 @@ mod tests {
         }))
         .unwrap();
         assert!(matches!(locator, HighlightLocator::Pdf { rects: None, .. }));
+    }
+
+    /// Idempotent highlight create decides replay-versus-divergence by comparing locators, so
+    /// equality has to be structural across every variant and every field, not variant-deep.
+    #[test]
+    fn locator_equality_is_structural_across_variants_and_fields() {
+        let pdf = |page, snapshot: &str, rects| HighlightLocator::Pdf {
+            page,
+            x: 1.0,
+            y: 2.0,
+            width: 3.0,
+            height: 4.0,
+            text_snapshot: snapshot.into(),
+            rects,
+        };
+        let rect = |x| {
+            Some(vec![PdfRect {
+                x,
+                y: 2.0,
+                width: 3.0,
+                height: 4.0,
+            }])
+        };
+
+        assert_eq!(pdf(2, "quote", None), pdf(2, "quote", None));
+        assert_ne!(pdf(2, "quote", None), pdf(3, "quote", None));
+        assert_ne!(pdf(2, "quote", None), pdf(2, "other", None));
+        assert_ne!(pdf(2, "quote", None), pdf(2, "quote", rect(1.0)));
+        assert_ne!(pdf(2, "quote", rect(1.0)), pdf(2, "quote", rect(9.0)));
+
+        let epub = |chapter: &str, start| HighlightLocator::Epub {
+            chapter: chapter.into(),
+            start_offset: start,
+            end_offset: 20,
+        };
+        assert_eq!(epub("ch1", 10), epub("ch1", 10));
+        assert_ne!(epub("ch1", 10), epub("ch2", 10));
+        assert_ne!(epub("ch1", 10), epub("ch1", 11));
+
+        assert_ne!(
+            epub("ch1", 10),
+            HighlightLocator::Html {
+                start_offset: 10,
+                end_offset: 20,
+            },
+            "different variants are never equal, even with matching offsets"
+        );
     }
 }

--- a/backend/crates/ind-http-api/src/routes/documents/highlights.rs
+++ b/backend/crates/ind-http-api/src/routes/documents/highlights.rs
@@ -7,8 +7,10 @@ use super::*;
     request_body = CreateHighlightBody,
     responses(
         (status = 201, description = "Highlight created", body = HighlightResponse),
+        (status = 200, description = "Highlight already existed with identical content", body = HighlightResponse),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Document not found"),
+        (status = 409, description = "Highlight id already used with different content"),
         (status = 422, description = "Document not yet rendered, or validation error"),
         (status = 503, description = "Document reader service not configured"),
     ),
@@ -27,20 +29,28 @@ pub async fn create_document_highlight(
 ) -> Result<(http::StatusCode, crate::extract::Json<HighlightResponse>), ApiError> {
     let ops = require_document_reader_ops(&state)?;
     let document_id = parse_document_id(&document_id)?;
-    let highlight = ops
+    let creation = ops
         .create_highlight(
             auth_user.user_id,
             document_id,
-            body.color,
-            body.text_content,
-            Some(body.locator.into()),
-            body.source_locator.map(Into::into),
+            CreateHighlightRequest {
+                requested_id: body.id,
+                color: body.color,
+                text_content: body.text_content,
+                locator: Some(body.locator.into()),
+                source_locator: body.source_locator.map(Into::into),
+            },
         )
         .await
         .map_err(ApiError::from)?;
+    let status = if creation.created {
+        http::StatusCode::CREATED
+    } else {
+        http::StatusCode::OK
+    };
     Ok((
-        http::StatusCode::CREATED,
-        crate::extract::Json(HighlightResponse::from_domain(highlight)),
+        status,
+        crate::extract::Json(HighlightResponse::from_domain(creation.highlight)),
     ))
 }
 

--- a/backend/crates/ind-http-api/src/routes/documents/highlights.rs
+++ b/backend/crates/ind-http-api/src/routes/documents/highlights.rs
@@ -8,6 +8,7 @@ use super::*;
     responses(
         (status = 201, description = "Highlight created", body = HighlightResponse),
         (status = 200, description = "Highlight already existed with identical content", body = HighlightResponse),
+        (status = 400, description = "Malformed body or highlight id"),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Document not found"),
         (status = 409, description = "Highlight id already used with different content"),

--- a/backend/crates/ind-http-api/src/routes/documents/mod.rs
+++ b/backend/crates/ind-http-api/src/routes/documents/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod toc;
 use axum::Router;
 use axum::extract::{Path, State};
 use axum::routing::{get, patch, post};
-use ind_application::ports::DocumentReaderOperations;
+use ind_application::ports::{CreateHighlightRequest, DocumentReaderOperations};
 
 use crate::error::ApiError;
 use crate::extract::ValidatedJson;

--- a/backend/crates/ind-http-api/src/routes/extension/dto.rs
+++ b/backend/crates/ind-http-api/src/routes/extension/dto.rs
@@ -204,6 +204,11 @@ pub struct PatchExtensionEntryBody {
 
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct ExtensionCreateHighlightBody {
+    /// Client-generated `hlt_` id. Replaying it with identical content returns the stored
+    /// highlight with 200; reusing it with different content is a conflict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub id: Option<ind_domain::HighlightId>,
     pub color: String,
     pub text_content: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/backend/crates/ind-http-api/src/routes/extension/entries.rs
+++ b/backend/crates/ind-http-api/src/routes/extension/entries.rs
@@ -190,21 +190,29 @@ pub async fn extension_create_highlight(
             .ok_or(ApiError::ServiceUnavailable {
                 message: "document reader service not configured".into(),
             })?;
-    let highlight = document_reader_ops
+    let creation = document_reader_ops
         .create_highlight(
             auth_user.user_id,
             joined.document.id,
-            body.color,
-            body.text_content,
-            body.locator.map(Into::into),
-            body.source_locator.map(Into::into),
+            CreateHighlightRequest {
+                requested_id: body.id,
+                color: body.color,
+                text_content: body.text_content,
+                locator: body.locator.map(Into::into),
+                source_locator: body.source_locator.map(Into::into),
+            },
         )
         .await
         .map_err(ApiError::from)?;
 
+    let status = if creation.created {
+        http::StatusCode::CREATED
+    } else {
+        http::StatusCode::OK
+    };
     Ok((
-        http::StatusCode::CREATED,
-        crate::extract::Json(HighlightResponse::from_domain(highlight)),
+        status,
+        crate::extract::Json(HighlightResponse::from_domain(creation.highlight)),
     ))
 }
 

--- a/backend/crates/ind-http-api/src/routes/extension/entries.rs
+++ b/backend/crates/ind-http-api/src/routes/extension/entries.rs
@@ -143,8 +143,11 @@ pub async fn extension_list_highlights(
     request_body = ExtensionCreateHighlightBody,
     responses(
         (status = 201, description = "Created highlight", body = HighlightResponse),
+        (status = 200, description = "Highlight already existed with identical content", body = HighlightResponse),
+        (status = 400, description = "Malformed body or highlight id"),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Saved entry not found"),
+        (status = 409, description = "Highlight id already used with different content"),
         (status = 422, description = "Validation error"),
         (status = 503, description = "Document reader service not configured"),
     ),
@@ -155,7 +158,7 @@ pub async fn extension_create_highlight(
     State(state): State<AppState>,
     RequireExtensionAccess(auth_user): RequireExtensionAccess,
     Path(library_entry_id): Path<String>,
-    axum::Json(body): axum::Json<ExtensionCreateHighlightBody>,
+    crate::extract::Json(body): crate::extract::Json<ExtensionCreateHighlightBody>,
 ) -> Result<(http::StatusCode, crate::extract::Json<HighlightResponse>), ApiError> {
     let entry_id = parse_extension_entry_id(&library_entry_id)?;
     let joined = library_entry_for_alias(&state, auth_user.user_id, entry_id).await?;

--- a/backend/crates/ind-http-api/src/routes/extension/mod.rs
+++ b/backend/crates/ind-http-api/src/routes/extension/mod.rs
@@ -5,7 +5,7 @@ use http::HeaderMap;
 use ind_application::handlers::extension_save::{
     FullArchiveInput, QuickSaveInput, ReaderSaveInput,
 };
-use ind_application::ports::PatchExtensionEntryRequest;
+use ind_application::ports::{CreateHighlightRequest, PatchExtensionEntryRequest};
 use ind_domain::{ClientType, ItemType};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/backend/crates/ind-http-api/src/routes/highlights/dto.rs
+++ b/backend/crates/ind-http-api/src/routes/highlights/dto.rs
@@ -250,6 +250,11 @@ impl From<ind_domain::HighlightSourceLocator> for SourceLocatorSchema {
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateHighlightBody {
+    /// Client-generated `hlt_` id. Replaying it with identical content returns the stored
+    /// highlight with 200; reusing it with different content is a conflict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub id: Option<ind_domain::HighlightId>,
     pub color: String,
     pub text_content: String,
     #[schema(value_type = LocatorSchemaFlat)]

--- a/backend/crates/ind-persistence/src/repos/highlight_repo.rs
+++ b/backend/crates/ind-persistence/src/repos/highlight_repo.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use ind_application::AppError;
 use ind_application::repos::event::MutationSideEffects;
-use ind_application::repos::highlight::HighlightRepository;
+use ind_application::repos::highlight::{HighlightRepository, HighlightWrite};
 use ind_domain::{
     DocumentId, DomainError, Highlight, HighlightId, HighlightNote, NewHighlight, Tag, TagId,
     UserId,
@@ -80,7 +80,7 @@ impl HighlightRepository for PgHighlightRepository {
         &self,
         highlight: &NewHighlight,
         effects: MutationSideEffects,
-    ) -> Result<Highlight, AppError> {
+    ) -> Result<HighlightWrite, AppError> {
         self.create_for_document_impl(highlight, effects).await
     }
 

--- a/backend/crates/ind-persistence/src/repos/highlight_repo/document.rs
+++ b/backend/crates/ind-persistence/src/repos/highlight_repo/document.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 
 use ind_application::AppError;
 use ind_application::repos::event::MutationSideEffects;
+use ind_application::repos::highlight::HighlightWrite;
 use ind_domain::{DocumentId, Highlight, NewHighlight, UserId};
 
 use super::super::write_helpers::apply_mutation_side_effects_tx;
@@ -15,7 +16,7 @@ impl PgHighlightRepository {
         &self,
         highlight: &NewHighlight,
         effects: MutationSideEffects,
-    ) -> Result<Highlight, AppError> {
+    ) -> Result<HighlightWrite, AppError> {
         let now = Utc::now();
         let locator_json = highlight
             .locator
@@ -36,6 +37,7 @@ impl PgHighlightRepository {
             HighlightRow,
             "INSERT INTO highlights (id, document_id, user_id, color, text_content, locator, source_locator, created_at, updated_at) \
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8) \
+             ON CONFLICT DO NOTHING \
              RETURNING id, document_id AS \"document_id!\", user_id, color, text_content, locator, source_locator, created_at, updated_at",
             highlight.id.into_uuid(),
             highlight.document_id.into_uuid(),
@@ -46,14 +48,21 @@ impl PgHighlightRepository {
             source_locator_json,
             now,
         )
-        .fetch_one(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await
         .map_err(map_sqlx_error)?;
+
+        let Some(row) = row else {
+            tx.rollback().await.map_err(map_sqlx_error)?;
+            return Ok(HighlightWrite::IdTaken);
+        };
 
         apply_mutation_side_effects_tx(&mut tx, effects).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
-        Highlight::try_from(row)
+        Ok(HighlightWrite::Inserted(Box::new(Highlight::try_from(
+            row,
+        )?)))
     }
 
     pub(super) async fn list_by_document_impl(

--- a/backend/test-invariants.toml
+++ b/backend/test-invariants.toml
@@ -861,3 +861,19 @@ owner_layer = "http"
 path = "apps/ind-api/tests/api/reading_events_position_tests.rs"
 test = "every_document_type_records_and_returns_its_own_position"
 rationale = "Reading position is one model for every artifact: articles, books, PDFs, video and podcast must each record and return their own coordinates, and no type may lose a field the others keep."
+
+[[invariants]]
+id = "highlight-create-idempotent"
+risk = "concurrency-idempotency"
+owner_layer = "http"
+path = "apps/ind-api/tests/api/highlight_idempotency_tests.rs"
+test = "concurrent_identical_creates_produce_one_highlight"
+rationale = "Retrying a highlight create from an offline queue must never duplicate the highlight, even when two identical requests race."
+
+[[invariants]]
+id = "highlight-replay-side-effects"
+risk = "event-delivery"
+owner_layer = "http"
+path = "apps/ind-api/tests/api/highlight_idempotency_tests.rs"
+test = "replay_does_not_repeat_highlight_side_effects"
+rationale = "An exact replay must not re-emit document.highlighted or re-queue the search reindex; neither is visible in the HTTP response."


### PR DESCRIPTION
`POST /documents/{id}/highlights` and the extension entries highlight route accept an optional client-generated `hlt_` id so an offline queue can retry a create safely. The write is insert-first (`INSERT ... ON CONFLICT DO NOTHING ... RETURNING`): no row means the id is taken, so the transaction rolls back before side effects run and the service reloads scoped by user. Identical content returns 200 with the stored row, divergent content or another owner returns 409, and callers that omit the id are unchanged. Lookup-then-insert was rejected because two concurrent identical requests both miss the lookup and one gets a 409 for what is by definition a replay.

Stacked on #49; retarget to main once that merges. The last commit fixes a divergence this slice exposed: the extension route extracted with bare `axum::Json`, so a malformed id came back as a plain-text 422 while the documents route returned a 400 problem document. One known gap is documented on the port rather than fixed: a later `update_color` moves the stored row out from under a still-queued retry, turning a correct retry into a 409, which needs a client-side FIFO guarantee the server cannot enforce. No client artifacts here.